### PR TITLE
Stargazers fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='tap-github',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_github'],
-      install_requires=['singer-python==1.6.0',
+      install_requires=['singer-python==1.7.0',
                         'requests==2.13.0'],
       entry_points='''
           [console_scripts]
@@ -19,7 +19,8 @@ setup(name='tap-github',
       package_data = {
           'tap_github': [
               'commits.json',
-              'issues.json'
+              'issues.json',
+              'stargazers.json'
               ]
           }
 )

--- a/tap_github.py
+++ b/tap_github.py
@@ -98,6 +98,10 @@ def get_all_stargazers(repo_path, state):
             counter.increment(len(stargazers))
             if len(stargazers) > 0:
                 last_stargazer_time = stargazers[-1]['starred_at']
+
+            for stargazer in stargazers:
+                stargazer['starred_repo'] = repo_path
+
             singer.write_records('stargazers', stargazers)
 
     state['stargazers'] = last_stargazer_time
@@ -118,7 +122,7 @@ def do_sync(config, state):
 
     singer.write_schema('commits', schemas['commits'], 'sha')
     singer.write_schema('issues', schemas['issues'], 'id')
-    singer.write_schema('stargazers', schemas['stargazers'], 'id')
+    singer.write_schema('stargazers', schemas['stargazers'], ['id','starred_repo'])
     state = get_all_commits(repo_path, state)
     state = get_all_issues(repo_path, state)
     state = get_all_stargazers(repo_path, state)

--- a/tap_github.py
+++ b/tap_github.py
@@ -101,6 +101,7 @@ def get_all_stargazers(repo_path, state):
 
             for stargazer in stargazers:
                 stargazer['starred_repo'] = repo_path
+                stargazer['user_id'] = stargazer['user']['id']
 
             singer.write_records('stargazers', stargazers)
 
@@ -122,7 +123,7 @@ def do_sync(config, state):
 
     singer.write_schema('commits', schemas['commits'], 'sha')
     singer.write_schema('issues', schemas['issues'], 'id')
-    singer.write_schema('stargazers', schemas['stargazers'], ['id','starred_repo'])
+    singer.write_schema('stargazers', schemas['stargazers'], ['user_id','starred_repo'])
     state = get_all_commits(repo_path, state)
     state = get_all_issues(repo_path, state)
     state = get_all_stargazers(repo_path, state)

--- a/tap_github/stargazers.json
+++ b/tap_github/stargazers.json
@@ -9,6 +9,9 @@
             }
           }
         },
+        "user_id": {
+            "type": "integer"
+        },
         "starred_at": {
             "type": "string",
             "format": "date-time"

--- a/tap_github/stargazers.json
+++ b/tap_github/stargazers.json
@@ -1,11 +1,20 @@
 {
     "type": "object",
     "properties": {
-	"id": {"type": "integer"},
-	"starred_at": {
+        "user": {
+          "type": ["null", "object"],
+          "properties": {
+            "id": {
+                "type": "integer"
+            }
+          }
+        },
+        "starred_at": {
             "type": "string",
             "format": "date-time"
-	}
-    },
-    "required": ["id"]
+        },
+        "starred_repo": {
+            "type": "string"
+        }
+    }
 }


### PR DESCRIPTION
- Use singer-python 1.7.0
- Adds the config repo as a field on each Stargazer object. This is valuable if combining the data from multiple repos together in your destination.
- Updated PK for Stargazers
- Updated schema to represent new field
- Add stargazers.json to setup.py to fix PyPi package
