### PR TITLE
Allow synchronization from mulitiple repos at a time

### DIFF
--- a/tap_github.py
+++ b/tap_github.py
@@ -142,24 +142,28 @@ def main():
     args = parser.parse_args()
 
     with open(args.config) as config_file:
-        config = json.load(config_file)
+        configList = json.load(config_file)
 
-    missing_keys = []
-    for key in ['access_token', 'repository']:
-        if key not in config:
-            missing_keys += [key]
+    if not isinstance(configList, list):
+      configList = [configList]
 
-    if len(missing_keys) > 0:
-        logger.fatal("Missing required configuration keys: {}".format(missing_keys))
-        exit(1)
+    for config in configList:
+      missing_keys = []
+      for key in ['access_token', 'repository']:
+          if key not in config:
+              missing_keys += [key]
 
-    state = {}
-    if args.state:
-        with open(args.state, 'r') as file:
-            for line in file:
-                state = json.loads(line.strip())
+      if len(missing_keys) > 0:
+          logger.fatal("Missing required configuration keys: {}".format(missing_keys))
+          exit(1)
 
-    do_sync(config, state)
+      state = {}
+      if args.state:
+          with open(args.state, 'r') as file:
+              for line in file:
+                  state = json.loads(line.strip())
+
+      do_sync(config, state)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This branch lets you specify the config file as an array, which will sync all repo-key pairs in the config.

##### Functional tests
- Add multiple key-pairs in the config file like so:
```
[ 
  { "access_token": "12345asbcdcd", "repository":"bengarvey/lineage"},
  { "access_token": "12345asbcdcd", "repository":"bengarvey/tap-pagerduty"}
]
```

###### Regresstion tests
- Use the old format, make sure it still works
```
  { "access_token": "12345asbcdcd", "repository":"bengarvey/lineage"}
```