### PR TITLE
Raise AuthException on 401 response

### DIFF
--- a/tap_github.py
+++ b/tap_github.py
@@ -23,10 +23,16 @@ KEY_PROPERTIES = {
     'reviews': ['id']
 }
 
+class AuthException(Exception):
+    pass
+
 def authed_get(source, url, headers={}):
     with metrics.http_request_timer(source) as timer:
         session.headers.update(headers)
         resp = session.request(method='get', url=url)
+        if resp.status_code == 401:
+            raise AuthException(resp.text)
+
         timer.tags[metrics.Tag.http_status_code] = resp.status_code
         return resp
 


### PR DESCRIPTION
The tap was not catching 401 responses (Auth Error).  This changes the tap so it looks for a 401 and raises an exception when it happens.