### PR TITLE
Allowing labels under issues to be a string

### DIFF
--- a/tap_github/issues.json
+++ b/tap_github/issues.json
@@ -6,7 +6,7 @@
 	    "type": ["null", "integer"]
 	},
 	"labels": {
-	    "type": ["null", "object"],
+	    "type": ["null", "object", "string"],
 	    "additionalProperties": false,
 	    "properties": {
 		"name": {


### PR DESCRIPTION
Labels can be an array, labels can be null...and labels can be []! What a surprise!

This allows [] to come in.