### PR TITLE
Add support for comments stream

### DIFF
--- a/tap_github.py
+++ b/tap_github.py
@@ -165,7 +165,6 @@ def get_all_pull_requests(schemas, config, state, mdata):
                         for comment_rec in get_comments_for_pr(pr_num, schemas['comments'], config, state, mdata):
                             singer.write_record('comments', comment_rec, time_extracted=extraction_time)
                             singer.write_bookmark(state, 'comments', 'since', singer.utils.strftime(extraction_time))
-                            # comments_counter.increment()
 
     return state
 

--- a/tap_github/comments.json
+++ b/tap_github/comments.json
@@ -1,0 +1,125 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": ["null", "integer"]
+    },
+    "user": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "login": {
+          "type": ["null", "string"]
+        },
+        "id": {
+          "type": ["null", "integer"]
+        }
+      }
+    },
+    "body": {
+      "type": ["null", "string"]
+    },
+    "node_id": {
+      "type": ["null", "string"]
+    },
+    "pull_request_review_id": {
+      "type": ["null", "integer"]
+    },
+    "diff_hunk": {
+      "type": ["null", "string"]
+    },
+    "path": {
+      "type": ["null", "string"]
+    },
+    "position": {
+      "type": ["null", "integer"]
+    },
+    "original_position": {
+      "type": ["null", "integer"]
+    },
+    "commit_id": {
+      "type": ["null", "string"]
+    },
+    "original_commit_id": {
+      "type": ["null", "string"]
+    },
+    "in_reply_to_id": {
+      "type": ["null", "integer"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "html_url": {
+      "type": ["null", "string"]
+    },
+    "pull_request_url": {
+      "type": ["null", "string"]
+    },
+    "assignee": {
+      "type": ["null", "string"]
+    },
+    "assignees": {
+      "type": ["null", "string"]
+    },
+    "author_association": {
+      "type": ["null", "string"]
+    },
+    "base": {
+      "type": ["null", "string"]
+    },
+    "comments_url": {
+      "type": ["null", "string"]
+    },
+    "commits_url": {
+      "type": ["null", "string"]
+    },
+    "diff_url": {
+      "type": ["null", "string"]
+    },
+    "head": {
+      "type": ["null", "string"]
+    },
+    "html_url": {
+      "type": ["null", "string"]
+    },
+    "issue_url": {
+      "type": ["null", "string"]
+    },
+    "labels": {
+      "type": ["null", "string"]
+    },
+    "locked": {
+      "type": ["null", "string"]
+    },
+    "merge_commit_sha": {
+      "type": ["null", "string"]
+    },
+    "milestone": {
+      "type": ["null", "string"]
+    },
+    "patch_url": {
+      "type": ["null", "string"]
+    },
+    "requested_reviewers": {
+      "type": ["null", "string"]
+    },
+    "requested_teams": {
+      "type": ["null", "string"]
+    },
+    "review_comment_url": {
+      "type": ["null", "string"]
+    },
+    "review_comments_url": {
+      "type": ["null", "string"]
+    },
+    "statuses_url": {
+      "type": ["null", "string"]
+    }
+  }
+}


### PR DESCRIPTION
This adds a comments stream for extracting [comments for a pull request](https://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request).

Comments stream is added as a substream to pull_requests, similar to reviews. Included is support for validating dependency of pull_requests being selected.

TODO: Add support for metrics.comments_counter 