### PR TITLE
Assignee can be more than null

### DIFF
--- a/tap_github/issues.json
+++ b/tap_github/issues.json
@@ -72,8 +72,10 @@
     },
     "assignee": {
       "type": [
-        "null"
-      ]
+        "null",
+        "object"
+      ],
+      "properties": {}
     },
     "updated_at": {
       "type": [


### PR DESCRIPTION
This resolves #36. The Assignee field on an issue can have an object and is not always `null`. This PR does not build out all of the properties and those should be added as needed in future issues.

I tested this locally with `target-stitch` and confirm that I am no longer seeing transform errors. Assignee object fields are now being filtered by the target since they are no yet outlined in the schema.