### PR TITLE
Fix: Status code 403 was hidden from users. Make failure obvious

### DIFF
--- a/tap_github.py
+++ b/tap_github.py
@@ -87,6 +87,8 @@ def authed_get(source, url, headers={}):
         resp = session.request(method='get', url=url)
         if resp.status_code == 401:
             raise AuthException(resp.text)
+        if resp.status_code == 403:
+            raise AuthException(resp.text)
         if resp.status_code == 404:
             raise NotFoundException(resp.text)
 


### PR DESCRIPTION
# Motivation

While trying to use `tap-github` with a user whose permissions are _severely_ limited, we ran into the following problem:

https://circleci.com/gh/datamill-co/target-postgres/106

### `tap-github`'s output

```
CRITICAL 'str' object does not support item assignment
Traceback (most recent call last):
  File "/code/venv--tap-github/bin/tap-github", line 11, in <module>
    load_entry_point('tap-github==1.3.1', 'console_scripts', 'tap-github')()
  File "/code/venv--tap-github/lib/python3.7/site-packages/singer/utils.py", line 225, in wrapped
    return fnc(*args, **kwargs)
  File "/code/venv--tap-github/lib/python3.7/site-packages/tap_github.py", line 513, in main
    do_sync(args.config, args.state, catalog)
  File "/code/venv--tap-github/lib/python3.7/site-packages/tap_github.py", line 486, in do_sync
    state = sync_func(stream_schema, repo, state, mdata)
  File "/code/venv--tap-github/lib/python3.7/site-packages/tap_github.py", line 288, in get_all_collaborators
    collaborator['_sdc_repository'] = repo_path
TypeError: 'str' object does not support item assignment
Exited with code 1
```

### `curl github...`'s output

```
root@aa89368a33ad:/code# curl -v -H "Authorization: token REDACTED" https://api.github.com/repos/datamill-co/target-postgres/collaborators
*   Trying 192.30.253.116...
* TCP_NODELAY set
* Connected to api.github.com (192.30.253.116) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.2 (OUT), TLS header, Certificate Status (22):
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.com
*  start date: Jun 19 00:00:00 2018 GMT
*  expire date: Jul 10 12:00:00 2019 GMT
*  subjectAltName: host "api.github.com" matched cert's "*.github.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
> GET /repos/datamill-co/target-postgres/collaborators HTTP/1.1
> Host: api.github.com
> User-Agent: curl/7.52.1
> Accept: */*
> Authorization: token REDACTED
> 
< HTTP/1.1 403 Forbidden
< Server: GitHub.com
< Date: Tue, 18 Dec 2018 18:33:17 GMT
< Content-Type: application/json; charset=utf-8
< Content-Length: 173
< Status: 403 Forbidden
< X-RateLimit-Limit: 5000
< X-RateLimit-Remaining: 4983
< X-RateLimit-Reset: 1545160294
< X-OAuth-Scopes: public_repo
< X-Accepted-OAuth-Scopes: 
< X-GitHub-Media-Type: github.v3; format=json
< Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
< Access-Control-Allow-Origin: *
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< X-Frame-Options: deny
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
< Content-Security-Policy: default-src 'none'
< X-GitHub-Request-Id: DEC1:232F:1AA0E6A:3F0E776:5C193D6C
< 
{
  "message": "Must have push access to view repository collaborators.",
  "documentation_url": "https://developer.github.com/v3/repos/collaborators/#list-collaborators"
}
* Curl_http_done: called premature == 0
* Connection #0 to host api.github.com left intact
```

## Suggested Musical Pairing

https://soundcloud.com/phoenix/heatwave