### PR TITLE
Recover a review's submitted_at

### DIFF
--- a/tap_github/reviews.json
+++ b/tap_github/reviews.json
@@ -34,6 +34,10 @@
     },
     "pull_request_url": {
       "type": ["null", "string"]
+    },
+    "submitted_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }


### PR DESCRIPTION
According to https://platform.github.community/t/api-v3-pull-request-review-submitted-at/5049/2 there is a property named `submitted_at` for reviews, which is not (yet) in the documentation.

Please see the API's response:

![image](https://user-images.githubusercontent.com/474697/51344132-f0792100-1a65-11e9-9820-5d1b544fffa1.png)

Disclaimer: I edited the file straight on GitHub since I have no way to test my modification. I do use this tap on Stitch tho.