### PR TITLE
Treat issue dates as datetime type. Fixes #56

### DIFF
--- a/tap_github/issues.json
+++ b/tap_github/issues.json
@@ -57,7 +57,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "labels_url": {
       "type": [
@@ -82,7 +83,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "html_url": {
       "type": [
@@ -162,7 +164,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "_sdc_repository": {
       "type": ["string"]


### PR DESCRIPTION
This fixes the type sent of created_at, closed_at, and updated_at on the issues data.