### PR TITLE
Add tags schema with full table replication strategy to track releases

### DIFF
--- a/tap_github/tags.json
+++ b/tap_github/tags.json
@@ -1,0 +1,33 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": ["null", "string"]
+    },
+    "zipball_url": {
+      "type": ["null", "string"]
+    },
+    "tarball_url": {
+      "type": ["null", "string"]
+    },
+    "commit": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "sha": {
+          "type": ["null", "string"]
+        },
+        "url": {
+          "type": ["null", "string"]
+        }
+      }
+    },
+    "node_id": {
+      "type": ["null", "string"]
+    },
+    "_sdc_repository": {
+      "type": ["string"]
+    }
+  }
+}


### PR DESCRIPTION
Added basic support for tags for github repos - all tags will be replicated on each run of the tap for a given repo.

Currently tracking the following for tags:
`{
  "name",
  "zipball_url",
  "tarball_url",
  "commit": {
    "sha",
    "url"
  },
  "node_id"
}`