### PR TITLE
bump to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.7.0
+  * Adds many new streams [#70](https://github.com/singer-io/tap-github/pull/70)
+
 # 1.6.0
   * Adds a new stream for PR Commits [#67](https://github.com/singer-io/tap-github/pull/67)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='1.6.0',
+      version='1.7.0',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change

Bump to 1.7.0

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
