### PR TITLE
Remove date-time format for String fields such as url, content_url, project_url, etc.

### DIFF
--- a/tap_github/commit_comments.json
+++ b/tap_github/commit_comments.json
@@ -14,8 +14,7 @@
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "id": {
         "type": [

--- a/tap_github/issue_milestones.json
+++ b/tap_github/issue_milestones.json
@@ -8,8 +8,7 @@
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "html_url": {
         "type": [

--- a/tap_github/project_cards.json
+++ b/tap_github/project_cards.json
@@ -8,8 +8,7 @@
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "id": {
         "type": [
@@ -73,22 +72,19 @@
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "content_url": {
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "project_url": {
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       }
     }
   }

--- a/tap_github/project_columns.json
+++ b/tap_github/project_columns.json
@@ -8,15 +8,13 @@
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "project_url": {
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "cards_url": {
         "type": [

--- a/tap_github/projects.json
+++ b/tap_github/projects.json
@@ -20,8 +20,7 @@
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "columns_url": {
         "type": [

--- a/tap_github/pull_request_reviews.json
+++ b/tap_github/pull_request_reviews.json
@@ -167,8 +167,7 @@
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "_links": {
         "type": [


### PR DESCRIPTION
# Description of change
I removed the date-time format section in the JSON files. Fields such as url, project_url, and others are string fields so it crashes the application that I use because it isn't the right format.