### PR TITLE
Bump version to 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.7.1
+  * Remove `"format": "date-time"` from JSON schema's for keys that are not dates [#72](https://github.com/singer-io/tap-github/pull/72)
+
 # 1.7.0
   * Adds many new streams [#70](https://github.com/singer-io/tap-github/pull/70)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='1.7.0',
+      version='1.7.1',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change

Bump to 1.7.1

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
