### PR TITLE
re-add pr_commits as sub_stream of pull_requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ config.json
 properties.json
 
 .vscode
+
+# Jetbrains IDE
+.idea

--- a/tap_github.py
+++ b/tap_github.py
@@ -877,7 +877,7 @@ SYNC_FUNCTIONS = {
 }
 
 SUB_STREAMS = {
-    'pull_requests': ['reviews', 'review_comments'],
+    'pull_requests': ['reviews', 'review_comments', 'pr_commits'],
     'projects': ['project_cards', 'project_columns'],
     'teams': ['team_members', 'team_memberships']
 }


### PR DESCRIPTION
# Description of change
Fixes #78 

`pr_commits` were originally added as a sub_stream to `pull_requests` in #67 . However, it looks like it was unintentionally removed from `pull_requests'` sub_stream in [this PR](https://github.com/singer-io/tap-github/commit/bddf69424917b13174cfd203a6cde7e6805ffdb4#diff-f26d495b1346c44875efc276d691e2fcL850). This PR simply adds it back in.

# Manual QA steps
 - I ran this locally and it completed successfully while syncing the pr_commits. 
 
# Risks
 - WW3
 
# Rollback steps
 - revert this branch
