### PR TITLE
Add base ref to pull request schema

### DIFF
--- a/tap_github/schemas/pull_requests.json
+++ b/tap_github/schemas/pull_requests.json
@@ -64,6 +64,15 @@
         }
       }
     },
+    "base": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "type": ["null", "string"]
+        }
+      }
+    },
     "merged_at": {
       "type": ["null", "string"],
       "format": "date-time"


### PR DESCRIPTION
# Description of change
This PR adds one more column to `pull_requests` to track the base branch a PR is targeting - this lets you distinguish between PR's merged to master and PR's merged into story branches, for example.
 
# Rollback steps
 - revert this branch
