### PR TITLE
Bump to v1.8.1, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.8.1
+  * Add stream `pr_commits` back in [#81](https://github.com/singer-io/tap-github/pull/81)
+
 # 1.8.0
   * Added team_memberships stream [#75](https://github.com/singer-io/tap-github/pull/75)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='1.8.0',
+      version='1.8.1',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
Version bump for #81 

# Manual QA steps
 - Ran tap with #81 and confirmed that we get records for `pr_commits`
 
# Risks
 - Low
 
# Rollback steps
 - revert #81 and bump the version
