### PR TITLE
Fix issue 83, projects.json and pull_request_reviews.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.8.2
+  * Fix [issue 83](https://github.com/singer-io/tap-github/issues/83) by removing `format: date-time` from `html_url` field in `projects.json`.
+
 # 1.8.1
   * Add stream `pr_commits` back in [#81](https://github.com/singer-io/tap-github/pull/81)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='1.8.1',
+      version='1.8.2',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/projects.json
+++ b/tap_github/projects.json
@@ -20,8 +20,7 @@
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "columns_url": {
         "type": [

--- a/tap_github/pull_request_reviews.json
+++ b/tap_github/pull_request_reviews.json
@@ -167,8 +167,7 @@
         "type": [
           "null",
           "string"
-        ],
-        "format": "date-time"
+        ]
       },
       "_links": {
         "type": [
@@ -200,8 +199,7 @@
                 "type": [
                   "null",
                   "string"
-                ],
-                "format": "date-time"
+                ]
               }
             }
           }


### PR DESCRIPTION
# Description of change
Fix [issue 83](https://github.com/singer-io/tap-github/issues/83) by removing `format: date-time` from `html_url` field in `projects.json` and `pull_request_url` and `href` fields in `pull_request_reviews.json`.

# Manual QA steps
Removed format param, ran discovery and sync. No issues.
 
# Risks
Low - very minor change to field in JSON schema.
 
# Rollback steps
Revert to 1.8.1
