### PR TITLE
fix: team schema parent field to object

### DIFF
--- a/tap_github/schemas/teams.json
+++ b/tap_github/schemas/teams.json
@@ -79,7 +79,7 @@
     "parent": {
       "type": [
         "null",
-        "string"
+        "object"
       ]
     }
   }


### PR DESCRIPTION
# Description of change
This change related to https://github.com/singer-io/tap-github/issues/94
I've taken it, since we're running into this issue in stitchdata load (which uses tap)

# Manual QA steps
At the moment stitch load throws 
```
Error persisting data to Stitch: 400: {'error': 'Record x for table teams did not conform to schema:\n#: #: no subschema matched out of the total 2 subschemas\n#: expected: null, found: JSONObject\n#/parent: #: no subschema matched out of the total 2 subschemas\n#/parent: expected: null, found: JSONObject\n#/parent: expected type: String, found: JSONObject\n'}
```
when a team has non-null parent
 Also according to GitHub docs, it is an object: https://docs.github.com/en/rest/reference/teams#list-child-teams

# Risks
Minimal, since its only changing type for one field
 
# Rollback steps
 - revert this branch
