### PR TITLE
stitch-validate-json checkout code not venv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-github/lib/python3.5/site-packages/tap_github/schemas/*.json
+            stitch-validate-json tap_github/schemas/*.json
       - run:
           name: 'pylint'
           command: |


### PR DESCRIPTION
# Description of change
Run the json validator against schemas in the checkout code rather than the virtual environment.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
