### PR TITLE
Add support for base details, such as 'ref', 'repo', 'label' and 'sha'

### DIFF
--- a/tap_github/schemas/pull_requests.json
+++ b/tap_github/schemas/pull_requests.json
@@ -66,7 +66,6 @@
     },
     "base": {
       "type": ["null", "object"],
-      "additionalProperties": false,
       "properties": {
         "ref": {
           "type": ["null", "string"]
@@ -78,7 +77,7 @@
           "type": ["null", "object"],
           "properties": {
             "id": {
-              "type": [ "null", "number" ]
+              "type": [ "null", "integer" ]
             },
             "name": {
               "type": [ "null", "string" ]

--- a/tap_github/schemas/pull_requests.json
+++ b/tap_github/schemas/pull_requests.json
@@ -64,6 +64,35 @@
         }
       }
     },
+    "base": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "type": ["null", "string"]
+        },
+        "label": {
+          "type": ["null", "string"]
+        },
+        "repo": {
+          "type": ["null", "object"],
+          "properties": {
+            "id": {
+              "type": [ "null", "number" ]
+            },
+            "name": {
+              "type": [ "null", "string" ]
+            },
+            "url": {
+              "type": [ "null", "string" ]
+            }
+          }
+        },
+        "sha": {
+          "type": ["null", "string"]
+        }
+      }
+    },
     "merged_at": {
       "type": ["null", "string"],
       "format": "date-time"


### PR DESCRIPTION
# Description of change

Adds the `base` node to the `pull_requests.json` definition. It includes the following new fields:
- `base.ref` _(so now we can tell where pull requests are targeted)_
- `base.label`
- `base.sha`
- `base.repo.id`
- `base.repo.name`
- `base.repo.url`

My test produced the following added result:
```
...
{
   "base":{
      "label":"felipefrancisco:master",
      "ref":"master",
      "sha":"0d77a1034b9dbf08b8f91369a65c13b9c726c722",
      "repo": {
         "id":215760822.0,
         "name":"analytics",
         "url":"https://api.github.com/repos/felipefrancisco/analytics"
      }
   }
}
...
```

The fields added to the `pull_requests.json` is directly matching the documentation provided in Github's official docs for the List Pull Requests endpoint:

https://docs.github.com/en/rest/reference/pulls#list-pull-requests

# Manual QA steps
- Follow the initial configuration steps in the README
- Add the `base` node from this PR to your `properties.json`
- Run `tap-github --config config.json --properties properties.json` and see the changes
 
# Risks
- None identified
 
# Rollback Steps
- Revert this branch
