### PR TITLE
TDL-7674: Added support for handling API rate limit exceeded

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import json
 import collections
+import time
 import requests
 import singer
 import singer.bookmarks as bookmarks
@@ -45,6 +46,9 @@ class AuthException(Exception):
     pass
 
 class NotFoundException(Exception):
+    pass
+
+class RateLimitExceeded(Exception):
     pass
 
 def translate_state(state, catalog, repositories):
@@ -96,6 +100,21 @@ def get_bookmark(state, repo, stream_name, bookmark_key):
         return repo_stream_dict.get(bookmark_key)
     return None
 
+def calculate_seconds(epoch):
+    current = time.time()
+    future = epoch
+    return int(round((future - current), 0))
+
+def rate_throttling(response):
+    if int(response.headers['X-RateLimit-Remaining']) == 0:
+        seconds_to_sleep = calculate_seconds(int(response.headers['X-RateLimit-Reset']))
+
+        if seconds_to_sleep > 600:
+            raise RateLimitExceeded("API rate limit exceeded, please try after {} seconds.".format(seconds_to_sleep))
+
+        logger.info("API rate limit exceeded, will sleep for %s seconds now.", seconds_to_sleep)
+        time.sleep(seconds_to_sleep)
+
 # pylint: disable=dangerous-default-value
 def authed_get(source, url, headers={}):
     with metrics.http_request_timer(source) as timer:
@@ -109,6 +128,7 @@ def authed_get(source, url, headers={}):
             raise NotFoundException(resp.text)
 
         timer.tags[metrics.Tag.http_status_code] = resp.status_code
+        rate_throttling(resp)
         return resp
 
 def authed_get_all_pages(source, url, headers={}):

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -102,8 +102,7 @@ def get_bookmark(state, repo, stream_name, bookmark_key):
 
 def calculate_seconds(epoch):
     current = time.time()
-    future = epoch
-    return int(round((future - current), 0))
+    return int(round((epoch - current), 0))
 
 def rate_throttling(response):
     if int(response.headers['X-RateLimit-Remaining']) == 0:
@@ -112,7 +111,7 @@ def rate_throttling(response):
         if seconds_to_sleep > 600:
             raise RateLimitExceeded("API rate limit exceeded, please try after {} seconds.".format(seconds_to_sleep))
 
-        logger.info("API rate limit exceeded, will sleep for %s seconds now.", seconds_to_sleep)
+        logger.info("API rate limit exceeded. Tap will retry the data collection after %s seconds.", seconds_to_sleep)
         time.sleep(seconds_to_sleep)
 
 # pylint: disable=dangerous-default-value

--- a/tests/test_github_discovery.py
+++ b/tests/test_github_discovery.py
@@ -2,7 +2,6 @@ import tap_tester.connections as connections
 import tap_tester.menagerie   as menagerie
 import tap_tester.runner      as runner
 import re
-import os
 
 from base import TestGithubBase
 
@@ -20,10 +19,6 @@ class TestGithubDiscovery(TestGithubBase):
                 in self.expected_metadata().items()}
 
     def test_run(self):
-        env_var = os.environ
-        print('>>>>>>')
-        print(dict(env_var))
-
         conn_id = connections.ensure_connection(self)
 
         #run in check mode

--- a/tests/test_github_discovery.py
+++ b/tests/test_github_discovery.py
@@ -2,6 +2,7 @@ import tap_tester.connections as connections
 import tap_tester.menagerie   as menagerie
 import tap_tester.runner      as runner
 import re
+import os
 
 from base import TestGithubBase
 
@@ -19,6 +20,10 @@ class TestGithubDiscovery(TestGithubBase):
                 in self.expected_metadata().items()}
 
     def test_run(self):
+        env_var = os.environ
+        print('>>>>>>')
+        print(dict(env_var))
+
         conn_id = connections.ensure_connection(self)
 
         #run in check mode

--- a/tests/unittests/test_rate_limit.py
+++ b/tests/unittests/test_rate_limit.py
@@ -1,0 +1,52 @@
+import tap_github.__init__ as tap_github
+import unittest
+from unittest import mock
+import time
+import requests
+
+def api_call():
+    return requests.get("https://api.github.com/rate_limit")
+
+@mock.patch('time.sleep')
+class TestRateLimit(unittest.TestCase):
+
+
+    def test_rate_limt_wait(self, mocked_sleep):
+
+        mocked_sleep.side_effect = None
+
+        resp = api_call()
+        resp.headers["X-RateLimit-Reset"] = int(round(time.time(), 0)) + 120
+        resp.headers["X-RateLimit-Remaining"] = 0
+
+        tap_github.rate_throttling(resp)
+
+        mocked_sleep.assert_called_with(120)
+        self.assertTrue(mocked_sleep.called)
+
+
+    def test_rate_limit_exception(self, mocked_sleep):
+
+        mocked_sleep.side_effect = None
+
+        resp = api_call()
+        resp.headers["X-RateLimit-Reset"] = int(round(time.time(), 0)) + 601
+        resp.headers["X-RateLimit-Remaining"] = 0
+
+        try:
+            tap_github.rate_throttling(resp)
+        except tap_github.RateLimitExceeded as e:
+            self.assertEquals(str(e), "API rate limit exceeded, please try after 601 seconds.")
+
+
+    def test_rate_limit_not_exceeded(self, mocked_sleep):
+
+        mocked_sleep.side_effect = None
+
+        resp = api_call()
+        resp.headers["X-RateLimit-Reset"] = int(round(time.time(), 0)) + 10
+        resp.headers["X-RateLimit-Remaining"] = 5
+
+        tap_github.rate_throttling(resp)
+
+        self.assertFalse(mocked_sleep.called)


### PR DESCRIPTION
# Description of change
TDL-7674: Handle API rate limit exceeded

# Manual QA steps
 - Explicitly added wait time more than 10 minutes and checked if exception occurred
 - Explicitly added wait time less than 10 minutes and checked if tap waits for that time
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
