### PR TITLE
TDL-13117: Added support for KeyError on fetching data from dictionary

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -236,14 +236,19 @@ def get_all_teams(schemas, repo_path, state, mdata):
                 singer.write_bookmark(state, repo_path, 'teams', {'since': singer.utils.strftime(extraction_time)})
                 counter.increment()
 
+                slug = r.get('slug')
+                if any(key in schemas for key in ('team_members', 'team_memberships')) and not slug:
+                    logger.error('Could not find slug in org: %s', org)
+                    continue
+
                 if schemas.get('team_members'):
-                    team_slug = r['slug']
+                    team_slug = slug
                     for team_members_rec in get_all_team_members(team_slug, schemas['team_members'], repo_path, state, mdata):
                         singer.write_record('team_members', team_members_rec, time_extracted=extraction_time)
                         singer.write_bookmark(state, repo_path, 'team_members', {'since': singer.utils.strftime(extraction_time)})
 
                 if schemas.get('team_memberships'):
-                    team_slug = r['slug']
+                    team_slug = slug
                     for team_memberships_rec in get_all_team_memberships(team_slug, schemas['team_memberships'], repo_path, state, mdata):
                         singer.write_record('team_memberships', team_memberships_rec, time_extracted=extraction_time)
 

--- a/tests/unittests/test_key_error.py
+++ b/tests/unittests/test_key_error.py
@@ -1,0 +1,76 @@
+import unittest
+from unittest import mock
+import singer
+import json
+import tap_github.__init__ as tap_github
+logger = singer.get_logger()
+
+class Mockresponse:
+    def __init__(self, resp):
+        self.json_data = resp
+
+    def json(self):
+        return [(self.json_data)]
+
+def get_response(json):
+    yield Mockresponse(resp=json)
+
+@mock.patch("tap_github.__init__.authed_get_all_pages")
+@mock.patch("tap_github.logger.error")
+class TestRateLimit(unittest.TestCase):
+
+    @mock.patch("tap_github.__init__.get_all_team_members")
+    def test_slug_and_sub_stream_in_resp(self, mocked_team_members, mocked_logger_error, mocked_request):
+        """
+            "slug" is present in responnse and "team_members" is selected in schema,
+            so function will perform smoothly and get data for "team_members"
+        """
+        schemas = {"team_members": "None"}
+        json = {"key": "value", "slug": "my-team"}
+        mocked_request.return_value = get_response(json)
+
+        tap_github.get_all_teams(schemas, "tap-github", {}, {})
+
+        self.assertEquals(mocked_logger_error.call_count, 0)
+        self.assertEquals(mocked_team_members.call_count, 1)
+
+
+    def test_not_slug_and_sub_stream_in_resp(self, mocked_logger_error, mocked_request):
+        """
+            "slug" is not given in response,
+            error will be generated
+        """
+        schemas = {"team_members": "None"}
+        json = {"key": "value"}
+        mocked_request.return_value = get_response(json)
+
+        tap_github.get_all_teams(schemas, "tap-github", {}, {})
+
+        self.assertEquals(mocked_logger_error.call_count, 1)
+        mocked_logger_error.assert_called_with('Could not find slug in org: %s', 'tap-github')
+    
+    def test_slug_and_not_sub_stream_in_resp(self, mocked_logger_error, mocked_request):
+        """
+            "slug" is present in responnse and "team_members" is not selected in schema,
+            so function will perform smoothly and not get the data for "team_members"
+        """
+
+        json = {"key": "value", "slug": "my-team"}
+        mocked_request.return_value = get_response(json)
+
+        tap_github.get_all_teams({}, "tap-github", {}, {})
+
+        self.assertEquals(mocked_logger_error.call_count, 0)
+
+    def test_not_slug_and_not_sub_stream_in_resp(self, mocked_logger_error, mocked_request):
+        """
+            "slug" is not given in response,
+            error will be generated
+        """
+
+        json = {"key": "value"}
+        mocked_request.return_value = get_response(json)
+
+        tap_github.get_all_teams({}, "tap-github", {}, {})
+
+        self.assertEquals(mocked_logger_error.call_count, 0)


### PR DESCRIPTION
# Description of change
TDL-13117: Avoid KeyError on calls to retrieve data from the dictionary

# Manual QA steps
 - Manually removed deselected "slug" and "user" from catalog file and checked if data was fetched
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
