### PR TITLE
TDL-13115: Added support for checking credentials during discovery mode

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -82,7 +82,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     400:{
         "raise_exception": BadRequestException,
-        "message": "A validation exception has occurred."
+        "message": "The request is missing or has a bad parameter."
     },
     401: {
         "raise_exception": BadCredentialsException,
@@ -107,7 +107,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     500: {
         "raise_exception": InternalServerError,
         "message": "An error has occurred at Github's end."
-    },
+    }
 }
 
 def translate_state(state, catalog, repositories):

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -156,11 +156,10 @@ def authed_get(source, url, headers={}):
     with metrics.http_request_timer(source) as timer:
         session.headers.update(headers)
         resp = session.request(method='get', url=url)
-        if resp.status_code != 200:
-            raise_for_error(resp)
-        else:
+        if resp.status_code == 200:
             timer.tags[metrics.Tag.http_status_code] = resp.status_code
             return resp
+        raise_for_error(resp)
 
 def authed_get_all_pages(source, url, headers={}):
     while True:

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -156,10 +156,12 @@ def authed_get(source, url, headers={}):
     with metrics.http_request_timer(source) as timer:
         session.headers.update(headers)
         resp = session.request(method='get', url=url)
-        if resp.status_code == 200:
+        if resp.status_code != 200:
+            raise_for_error(resp)
+            return None
+        else:
             timer.tags[metrics.Tag.http_status_code] = resp.status_code
             return resp
-        raise_for_error(resp)
 
 def authed_get_all_pages(source, url, headers={}):
     while True:

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -53,15 +53,35 @@ class AuthException(GithubException):
 class NotFoundException(GithubException):
     pass
 
-class BadRequestExecption(GithubException):
+class BadRequestException(GithubException):
     pass
 
 class InternalServerError(GithubException):
     pass
 
+class UnprocessableError(GithubException):
+    pass
+
+class NotModifiedError(GithubException):
+    pass
+
+class MovedPermanentlyError(GithubException):
+    pass
+
+class ConflictError(GithubException):
+    pass
+
 ERROR_CODE_EXCEPTION_MAPPING = {
+    301: {
+        "raise_exception": MovedPermanentlyError,
+        "message": "The resource you are looking for is moved to another URL."
+    },
+    304: {
+        "raise_exception": NotModifiedError,
+        "message": "The requested resource has not been modified since the last time you accessed it."
+    },
     400:{
-        "raise_exception": BadRequestExecption,
+        "raise_exception": BadRequestException,
         "message": "A validation exception has occurred."
     },
     401: {
@@ -75,6 +95,14 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     404: {
         "raise_exception": NotFoundException,
         "message": "The resource you have specified cannot be found."
+    },
+    409: {
+        "raise_exception": ConflictError,
+        "message": "The request could not be completed due to a conflict with the current state of the server."
+    },
+    422: {
+        "raise_exception": UnprocessableError,
+        "message": "The request was not able to process right now."
     },
     500: {
         "raise_exception": InternalServerError,

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -95,7 +95,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.ConflictError as e:
             self.assertEquals(str(e), "HTTP-error-code: 409, Error: The request could not be completed due to a conflict with the current state of the server.")
 
-    def test_200_error(self, mocked_request):
+    def test_200_success(self, mocked_request):
         json = {"key": "value"}
         mocked_request.return_value = get_response(200, json)
 

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,0 +1,71 @@
+from unittest import mock
+import tap_github
+import unittest
+import requests
+
+class Mockresponse:
+    def __init__(self, status_code, json, raise_error, text=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.text = json
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("Sample message")
+
+    def json(self):
+        return self.text
+
+def get_response(status_code, json={}, raise_error=False):
+    return Mockresponse(status_code, json, raise_error)
+
+@mock.patch("requests.Session.request")
+class TestExceptionHandling(unittest.TestCase):
+    def test_400_error(self, mocked_request):
+        mocked_request.return_value = get_response(400, raise_error = True)
+        
+        try:
+            tap_github.authed_get("", "")
+        except tap_github.BadRequestExecption as e:
+            self.assertEquals(str(e), "HTTP-error-code: 400, Error: A validation exception has occurred.")
+    
+    def test_401_error(self, mocked_request):
+        mocked_request.return_value = get_response(401, raise_error = True)
+        
+        try:
+            tap_github.authed_get("", "")
+        except tap_github.BadCredentialsException as e:
+            self.assertEquals(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
+    
+    def test_403_error(self, mocked_request):
+        mocked_request.return_value = get_response(403, raise_error = True)
+        
+        try:
+            tap_github.authed_get("", "")
+        except tap_github.AuthException as e:
+            self.assertEquals(str(e), "HTTP-error-code: 403, Error: User doesn't have permission to access the resource.")
+    
+    def test_404_error(self, mocked_request):
+        mocked_request.return_value = get_response(404, raise_error = True)
+
+        try:
+            tap_github.authed_get("", "")
+        except tap_github.NotFoundException as e:
+            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found.")
+
+    def test_500_error(self, mocked_request):
+        mocked_request.return_value = get_response(500, raise_error = True)
+
+        try:
+            tap_github.authed_get("", "")
+        except tap_github.InternalServerError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 500, Error: An error has occurred at Github's end.")
+
+    def test_200_error(self, mocked_request):
+        json = {"key": "value"}
+        mocked_request.return_value = get_response(200, json)
+
+        resp = tap_github.authed_get("", "")
+        self.assertEquals(json, resp.json())

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -28,7 +28,7 @@ class TestExceptionHandling(unittest.TestCase):
         
         try:
             tap_github.authed_get("", "")
-        except tap_github.BadRequestExecption as e:
+        except tap_github.BadRequestException as e:
             self.assertEquals(str(e), "HTTP-error-code: 400, Error: A validation exception has occurred.")
     
     def test_401_error(self, mocked_request):
@@ -62,6 +62,38 @@ class TestExceptionHandling(unittest.TestCase):
             tap_github.authed_get("", "")
         except tap_github.InternalServerError as e:
             self.assertEquals(str(e), "HTTP-error-code: 500, Error: An error has occurred at Github's end.")
+
+    def test_301_error(self, mocked_request):
+        mocked_request.return_value = get_response(301, raise_error = True)
+
+        try:
+            tap_github.authed_get("", "")
+        except tap_github.MovedPermanentlyError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 301, Error: The resource you are looking for is moved to another URL.")
+
+    def test_304_error(self, mocked_request):
+        mocked_request.return_value = get_response(304, raise_error = True)
+
+        try:
+            tap_github.authed_get("", "")
+        except tap_github.NotModifiedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 304, Error: The requested resource has not been modified since the last time you accessed it.")
+
+    def test_422_error(self, mocked_request):
+        mocked_request.return_value = get_response(422, raise_error = True)
+
+        try:
+            tap_github.authed_get("", "")
+        except tap_github.UnprocessableError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 422, Error: The request was not able to process right now.")
+
+    def test_409_error(self, mocked_request):
+        mocked_request.return_value = get_response(409, raise_error = True)
+
+        try:
+            tap_github.authed_get("", "")
+        except tap_github.ConflictError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 409, Error: The request could not be completed due to a conflict with the current state of the server.")
 
     def test_200_error(self, mocked_request):
         json = {"key": "value"}

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -29,7 +29,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.BadRequestException as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: A validation exception has occurred.")
+            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
     
     def test_401_error(self, mocked_request):
         mocked_request.return_value = get_response(401, raise_error = True)

--- a/tests/unittests/test_verify_access.py
+++ b/tests/unittests/test_verify_access.py
@@ -1,0 +1,83 @@
+from unittest import mock
+import tap_github
+import unittest
+
+class Mockresponse:
+    def __init__(self, status_code, text=None):
+        self.status_code = status_code
+        self.text = ""
+
+def get_response(status_code):
+    return Mockresponse(status_code=status_code)
+
+@mock.patch("tap_github.logger.error")
+@mock.patch("requests.Session.request")
+class TestCredentials(unittest.TestCase):
+
+    def test_repo_invalid_creds(self, mocked_request, mocked_logger_error):
+        mocked_request.return_value = get_response(404)
+
+        with self.assertRaises(tap_github.NotFoundException):
+            tap_github.verify_repo_access("", "repo")
+        mocked_logger_error.assert_called_with("Access Token does not have permission to access private repositories or this account is not collaborator of '%s' this repository", "repo")
+
+    def test_org_invalid_creds_1(self, mocked_request, mocked_logger_error):
+        mocked_request.return_value = get_response(404)
+
+        with self.assertRaises(tap_github.NotFoundException):
+            tap_github.verify_org_access("", "org")
+        mocked_logger_error.assert_called_with("'%s' is not an oragnization", "org")
+
+    def test_org_invalid_creds_2(self, mocked_request, mocked_logger_error):
+        mocked_request.return_value = get_response(403)
+
+        with self.assertRaises(tap_github.AuthException):
+            tap_github.verify_org_access("", "org")
+        mocked_logger_error.assert_called_with("Not a member or access token has not permission to read orgs data for this '%s' organization", "org")
+
+    @mock.patch("tap_github.get_catalog")
+    def test_discover_valid_creds(self, mocked_get_catalog, mocked_request, mocked_logger_error):
+        mocked_request.return_value = get_response(200)
+        mocked_get_catalog.return_value = {}
+
+        tap_github.do_discover({"access_token": "access_token", "repository": "org/repo"})
+
+        self.assertTrue(mocked_get_catalog.call_count, 1)
+
+    @mock.patch("tap_github.get_catalog")
+    def test_discover_invalid_creds_1(self, mocked_get_catalog, mocked_request, mocked_logger_error):
+        mocked_request.return_value = get_response(404)
+        mocked_get_catalog.return_value = {}
+
+        with self.assertRaises(tap_github.NotFoundException):
+            tap_github.do_discover({"access_token": "access_token", "repository": "org/repo"})
+        self.assertEqual(mocked_get_catalog.call_count, 0)
+
+    @mock.patch("tap_github.get_catalog")
+    def test_discover_invalid_creds_2(self, mocked_get_catalog, mocked_request, mocked_logger_error):
+        mocked_request.return_value = get_response(403)
+        mocked_get_catalog.return_value = {}
+
+        with self.assertRaises(tap_github.AuthException):
+            tap_github.do_discover({"access_token": "access_token", "repository": "org/repo"})
+        self.assertEqual(mocked_get_catalog.call_count, 0)
+
+
+@mock.patch("tap_github.logger.info")
+@mock.patch("tap_github.verify_repo_access")
+@mock.patch("tap_github.verify_org_access")
+class TestRepoCallCount(unittest.TestCase):
+    """
+        Here 3 repos are given,
+        so tap will check creds for 3 repos
+    """
+    def test_repo_call_count(self, mocked_org, mocked_repo, mocked_logger_info):
+        mocked_org.return_value = None
+        mocked_repo.return_value = None
+
+        config = {"access_token": "access_token", "repository": "org1/repo1 org1/repo2 org2/repo1"}
+        tap_github.verify_access_for_repo_org(config)
+
+        self.assertEquals(mocked_logger_info.call_count, 3)
+        self.assertEquals(mocked_org.call_count, 3)
+        self.assertEquals(mocked_repo.call_count, 3)

--- a/tests/unittests/test_verify_access.py
+++ b/tests/unittests/test_verify_access.py
@@ -34,7 +34,7 @@ class TestCredentials(unittest.TestCase):
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: Please check the repository name 'repo' or you do not have sufficient permissions to access this repository.")
 
     def test_repo_wrong_creds(self, mocked_request):
-        json = {"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}
+        json = {"message": "Bad credentials", "documentation_url": "https://docs.github.com/rest"}
         mocked_request.return_value = get_response(401, json, True)
 
         try:
@@ -61,7 +61,7 @@ class TestCredentials(unittest.TestCase):
             self.assertEquals(str(e), "HTTP-error-code: 403, Error: {}".format(json))
 
     def test_org_wrong_creds(self, mocked_request):
-        json = {"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}
+        json = {"message": "Bad credentials", "documentation_url": "https://docs.github.com/rest"}
         mocked_request.return_value = get_response(401, json, True)
 
         try:
@@ -119,11 +119,11 @@ class TestCredentials(unittest.TestCase):
 @mock.patch("tap_github.verify_repo_access")
 @mock.patch("tap_github.verify_org_access")
 class TestRepoCallCount(unittest.TestCase):
-    """
-        Here 3 repos are given,
-        so tap will check creds for 3 repos
-    """
-    def test_repo_call_count(self, mocked_org, mocked_repo, mocked_logger_info):
+    def test_repo_call_count_positive(self, mocked_org, mocked_repo, mocked_logger_info):
+        """
+            Here 3 repos are given,
+            so tap will check creds for 3 repos
+        """
         mocked_org.return_value = None
         mocked_repo.return_value = None
 

--- a/tests/unittests/test_verify_access.py
+++ b/tests/unittests/test_verify_access.py
@@ -24,7 +24,7 @@ def get_response(status_code, json={}, raise_error=False):
 @mock.patch("requests.Session.request")
 class TestCredentials(unittest.TestCase):
 
-    def test_repo_invalid_creds(self, mocked_request):
+    def test_repo_not_found(self, mocked_request):
         json = {"message": "Not Found", "documentation_url": "https:/"}
         mocked_request.return_value = get_response(404, json, True)
 
@@ -33,7 +33,24 @@ class TestCredentials(unittest.TestCase):
         except tap_github.NotFoundException as e:
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: Please check the repository name 'repo' or you do not have sufficient permissions to access this repository.")
 
-    def test_repo_wrong_creds(self, mocked_request):
+    def test_repo_bad_request(self, mocked_request):
+        mocked_request.return_value = get_response(400, raise_error = True)
+
+        try:
+            tap_github.verify_repo_access("", "repo")
+        except tap_github.BadRequestException as e:
+            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
+
+    def test_repo_unprocessable_error(self, mocked_request):
+        json = {"message": "No commit found for SHA: !", "documentation_url": "https://docs.github.com/rest/reference/repos"}
+        mocked_request.return_value = get_response(422, json, True)
+
+        try:
+            tap_github.verify_repo_access("", "repo")
+        except tap_github.UnprocessableError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 422, Error: {}".format(json))
+
+    def test_repo_bad_creds(self, mocked_request):
         json = {"message": "Bad credentials", "documentation_url": "https://docs.github.com/rest"}
         mocked_request.return_value = get_response(401, json, True)
 
@@ -42,7 +59,7 @@ class TestCredentials(unittest.TestCase):
         except tap_github.BadCredentialsException as e:
             self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(json))
 
-    def test_org_invalid_creds_1(self, mocked_request):
+    def test_org_not_found(self, mocked_request):
         json = {"message": "Not Found", "documentation_url": "https:/"}
         mocked_request.return_value = get_response(404, json, True)
 
@@ -51,7 +68,24 @@ class TestCredentials(unittest.TestCase):
         except tap_github.NotFoundException as e:
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: {}".format(json))
 
-    def test_org_invalid_creds_2(self, mocked_request):
+    def test_org_bad_request(self, mocked_request):
+        mocked_request.return_value = get_response(400, raise_error = True)
+
+        try:
+            tap_github.verify_org_access("")
+        except tap_github.BadRequestException as e:
+            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
+
+    def test_org_unprocessable_error(self, mocked_request):
+        json = {"message": "No commit found for SHA: !", "documentation_url": "https://docs.github.com/rest/reference/repos"}
+        mocked_request.return_value = get_response(422, json, True)
+
+        try:
+            tap_github.verify_org_access("")
+        except tap_github.UnprocessableError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 422, Error: {}".format(json))
+
+    def test_org_forbidden(self, mocked_request):
         json = {'message': 'Must have admin rights to Repository.', 'documentation_url': 'https://docs.github.com/rest/reference/'}
         mocked_request.return_value = get_response(403, json, True)
 
@@ -60,7 +94,7 @@ class TestCredentials(unittest.TestCase):
         except tap_github.AuthException as e:
             self.assertEquals(str(e), "HTTP-error-code: 403, Error: {}".format(json))
 
-    def test_org_wrong_creds(self, mocked_request):
+    def test_org_bad_creds(self, mocked_request):
         json = {"message": "Bad credentials", "documentation_url": "https://docs.github.com/rest"}
         mocked_request.return_value = get_response(401, json, True)
 
@@ -79,7 +113,7 @@ class TestCredentials(unittest.TestCase):
         self.assertTrue(mocked_get_catalog.call_count, 1)
 
     @mock.patch("tap_github.get_catalog")
-    def test_discover_invalid_creds_1(self, mocked_get_catalog, mocked_request):
+    def test_discover_not_found(self, mocked_get_catalog, mocked_request):
         json = {"message": "Not Found", "documentation_url": "https:/"}
         mocked_request.return_value = get_response(404, json, True)
         mocked_get_catalog.return_value = {}
@@ -91,7 +125,30 @@ class TestCredentials(unittest.TestCase):
         self.assertEqual(mocked_get_catalog.call_count, 0)
 
     @mock.patch("tap_github.get_catalog")
-    def test_discover_invalid_creds_2(self, mocked_get_catalog, mocked_request):
+    def test_discover_bad_request(self, mocked_get_catalog, mocked_request):
+        mocked_request.return_value = get_response(400, raise_error = True)
+        mocked_get_catalog.return_value = {}
+
+        try:
+            tap_github.do_discover({"access_token": "access_token", "repository": "org/repo"})
+        except tap_github.BadRequestException as e:
+                self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
+        self.assertEqual(mocked_get_catalog.call_count, 0)
+
+    @mock.patch("tap_github.get_catalog")
+    def test_discover_unprocessable_error(self, mocked_get_catalog, mocked_request):
+        json = {"message": "No commit found for SHA: !", "documentation_url": "https://docs.github.com/rest/reference/repos"}
+        mocked_request.return_value = get_response(422, json, True)
+        mocked_get_catalog.return_value = {}
+
+        try:
+            tap_github.do_discover({"access_token": "access_token", "repository": "org/repo"})
+        except tap_github.UnprocessableError as e:
+                self.assertEquals(str(e), "HTTP-error-code: 422, Error: {}".format(json))
+        self.assertEqual(mocked_get_catalog.call_count, 0)
+
+    @mock.patch("tap_github.get_catalog")
+    def test_discover_bad_creds(self, mocked_get_catalog, mocked_request):
         json = {"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}
         mocked_request.return_value = get_response(401, json, True)
         mocked_get_catalog.return_value = {}
@@ -103,7 +160,7 @@ class TestCredentials(unittest.TestCase):
         self.assertEqual(mocked_get_catalog.call_count, 0)
 
     @mock.patch("tap_github.get_catalog")
-    def test_discover_invalid_creds_3(self, mocked_get_catalog, mocked_request):
+    def test_discover_forbidden(self, mocked_get_catalog, mocked_request):
         json = {'message': 'Must have admin rights to Repository.', 'documentation_url': 'https://docs.github.com/rest/reference/'}
         mocked_request.return_value = get_response(403, json, True)
         mocked_get_catalog.return_value = {}
@@ -119,10 +176,10 @@ class TestCredentials(unittest.TestCase):
 @mock.patch("tap_github.verify_repo_access")
 @mock.patch("tap_github.verify_org_access")
 class TestRepoCallCount(unittest.TestCase):
-    def test_repo_call_count_positive(self, mocked_org, mocked_repo, mocked_logger_info):
+    def test_repo_call_count(self, mocked_org, mocked_repo, mocked_logger_info):
         """
             Here 3 repos are given,
-            so tap will check creds for 3 repos
+            so tap will check creds for all 3 repos
         """
         mocked_org.return_value = None
         mocked_repo.return_value = None

--- a/tests/unittests/test_verify_access.py
+++ b/tests/unittests/test_verify_access.py
@@ -25,7 +25,8 @@ def get_response(status_code, json={}, raise_error=False):
 class TestCredentials(unittest.TestCase):
 
     def test_repo_invalid_creds(self, mocked_request):
-        mocked_request.return_value = get_response(404, True)
+        json = {"message": "Not Found", "documentation_url": "https:/"}
+        mocked_request.return_value = get_response(404, json, True)
 
         try:
             tap_github.verify_repo_access("", "repo")
@@ -79,7 +80,8 @@ class TestCredentials(unittest.TestCase):
 
     @mock.patch("tap_github.get_catalog")
     def test_discover_invalid_creds_1(self, mocked_get_catalog, mocked_request):
-        mocked_request.return_value = get_response(404, True)
+        json = {"message": "Not Found", "documentation_url": "https:/"}
+        mocked_request.return_value = get_response(404, json, True)
         mocked_get_catalog.return_value = {}
 
         try:


### PR DESCRIPTION
# Description of change
TDL-13115: do_discover should check permissions of the token given

# Manual QA steps
 - Intentionally made some credentials with limited permissions and checked if the tap throws error.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
