### PR TITLE
TDL-13660: Added support for checking if main stream is selected when fetching sub_stream data

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -175,14 +175,14 @@ class DependencyException(Exception):
 
 def validate_dependencies(selected_stream_ids):
     errs = []
-    msg_tmpl = ("Unable to extract {0} data. "
-                "To receive {0} data, you also need to select {1}.")
+    msg_tmpl = ("Unable to extract '{0}' data, "
+                "to receive '{0}' data, you also need to select '{1}'.")
 
-    if 'reviews' in selected_stream_ids and 'pull_requests' not in selected_stream_ids:
-        errs.append(msg_tmpl.format('reviews','pull_requests'))
-
-    if 'review_comments' in selected_stream_ids and 'pull_requests' not in selected_stream_ids:
-        errs.append(msg_tmpl.format('review_comments','pull_requests'))
+    for main_stream, sub_streams in SUB_STREAMS.items():
+        if main_stream not in selected_stream_ids:
+            for sub_stream in sub_streams:
+                if sub_stream in selected_stream_ids:
+                    errs.append(msg_tmpl.format(sub_stream, main_stream))
 
     if errs:
         raise DependencyException(" ".join(errs))

--- a/tests/unittests/test_sub_streams_selection.py
+++ b/tests/unittests/test_sub_streams_selection.py
@@ -1,0 +1,48 @@
+import unittest
+import tap_github.__init__ as tap_github
+
+class TestSubStreamSelection(unittest.TestCase):
+
+    def test_pull_request_sub_streams_selected(self):
+        selected_streams = ["reviews", "pull_requests"]
+        self.assertIsNone(tap_github.validate_dependencies(selected_streams))
+
+    def test_pull_request_sub_streams_not_selected(self):
+        selected_streams = ["reviews", "pr_commits"]
+        try:
+            tap_github.validate_dependencies(selected_streams)
+        except tap_github.DependencyException as e:
+            self.assertEquals(str(e), "Unable to extract 'reviews' data, to receive 'reviews' data, you also need to select 'pull_requests'. Unable to extract 'pr_commits' data, to receive 'pr_commits' data, you also need to select 'pull_requests'.")
+
+    def test_teams_sub_streams_selected(self):
+        selected_streams = ["teams", "team_members"]
+        self.assertIsNone(tap_github.validate_dependencies(selected_streams))
+
+    def test_teams_sub_streams_not_selected(self):
+        selected_streams = ["team_members"]
+        try:
+            tap_github.validate_dependencies(selected_streams)
+        except tap_github.DependencyException as e:
+            self.assertEquals(str(e), "Unable to extract 'team_members' data, to receive 'team_members' data, you also need to select 'teams'.")
+
+    def test_projects_sub_streams_selected(self):
+        selected_streams = ["projects", "project_cards"]
+        self.assertIsNone(tap_github.validate_dependencies(selected_streams))
+
+    def test_projects_sub_streams_not_selected(self):
+        selected_streams = ["project_columns"]
+        try:
+            tap_github.validate_dependencies(selected_streams)
+        except tap_github.DependencyException as e:
+            self.assertEquals(str(e), "Unable to extract 'project_columns' data, to receive 'project_columns' data, you also need to select 'projects'.")
+
+    def test_mixed_streams_positive(self):
+        selected_streams = ["pull_requests", "reviews", "collaborators", "team_members", "stargazers", "projects", "teams", "project_cards"]
+        self.assertIsNone(tap_github.validate_dependencies(selected_streams))
+
+    def test_mixed_streams_negative(self):
+        selected_streams = ["project_columns", "issues", "teams", "team_memberships", "projects", "releases", "review_comments"]
+        try:
+            tap_github.validate_dependencies(selected_streams)
+        except tap_github.DependencyException as e:
+            self.assertEquals(str(e), "Unable to extract 'review_comments' data, to receive 'review_comments' data, you also need to select 'pull_requests'.")


### PR DESCRIPTION
# Description of change
TDL-13660: Main streams must be selected while collecting data for sub-streams

# Manual QA steps
 - Manually selected sub_streams without main stream and checked if the error was generated.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
