### PR TITLE
TDL-13624: Make start date required field, add start_date in readme and sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ This tap:
 
     ```json
     {"access_token": "your-access-token",
-     "repository": "singer-io/tap-github singer-io/getting-started"}
+     "repository": "singer-io/tap-github singer-io/getting-started",
+     "start_date": "2021-01-01T00:00:00Z"}
     ```
 4. Run the tap in discovery mode to get properties.json file
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This tap:
 
 3. Create the config file
 
-    Create a JSON file containing the access token you just created
+    Create a JSON file containing the start date, access token you just created
     and the path to one or multiple repositories that you want to extract data from. Each repo path should be space delimited. The repo path is relative to
     `https://github.com/`. For example the path for this repository is
     `singer-io/tap-github`. 

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,4 +1,5 @@
 {
     "access_token": "abcdefghijklmnopqrstuvwxyz1234567890ABCD",
-    "repository": "singer-io/target-stitch"
+    "repository": "singer-io/target-stitch",
+    "start_date": "2021-01-01T00:00:00Z"
 }

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -13,7 +13,7 @@ from singer import metadata
 session = requests.Session()
 logger = singer.get_logger()
 
-REQUIRED_CONFIG_KEYS = ['access_token', 'repository']
+REQUIRED_CONFIG_KEYS = ['start_date', 'access_token', 'repository']
 
 KEY_PROPERTIES = {
     'commits': ['sha'],

--- a/tests/test_github_start_date.py
+++ b/tests/test_github_start_date.py
@@ -80,11 +80,10 @@ class GithubStartDateTest(TestGithubBase):
         for stream in expected_streams:
 
             # There are no data or not enough data for testing for below streams
-            # pull_request_review -> always skipped during sync mode
             # commit_comments, releases -> No data in tap-github repositery
             # issue_milestones -> One data for isuue_milestones so not able to pass incremental cases
             # projects, projects_columns, project_cards -> One record for project so not able to pass incremental cases
-            if stream in ["pull_request_reviews", "commit_comments", "releases", "issue_milestones", "projects", "project_columns", "project_cards"]:
+            if stream in ["commit_comments", "releases", "issue_milestones", "projects", "project_columns", "project_cards"]:
                 continue
             
             with self.subTest(stream=stream):


### PR DESCRIPTION
# Description of change
TDL-13624 : Respect start_date(#119) fixes
-  Added start_date in required config parameter.
-  Added start_date in config-sample of README.md and config.sample.json file.
-  Removed mention of the 'pull_request_reviews" stream from start date integration test as a stream is deleted.([#117](https://github.com/singer-io/tap-github/pull/117))

# Manual QA steps
 -  Verified that error is raised if start_date is not provided in config.
 
# Risks
 -  No risk
 
# Rollback steps
 - revert this branch
