### PR TITLE
Add assignee properties to issues schema

### DIFF
--- a/tap_github/schemas/issues.json
+++ b/tap_github/schemas/issues.json
@@ -77,7 +77,116 @@
         "null",
         "object"
       ],
-      "properties": {}
+      "properties": {
+        "gravatar_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "received_events_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "subscriptions_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "gists_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "html_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "repos_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "events_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "login": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "followers_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "starred_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "avatar_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "id": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "type": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "site_admin": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "node_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "organizations_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "following_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
     },
     "updated_at": {
       "type": [


### PR DESCRIPTION
# Description of change

Adds the nested assignee properties to the issues schema.

Closes #130 

# Manual QA steps

Strongly typed nested fields are required by bigquery but not postgres. So you'll need to manually test with bigquery.
 
# Risks

Possibly missing some properties. I don't know whether this will break existing integrations.
 
# Rollback steps
 - revert this branch
