### PR TITLE
Update commits schema

### DIFF
--- a/tap_github/schemas/commits.json
+++ b/tap_github/schemas/commits.json
@@ -5,6 +5,9 @@
     "_sdc_repository": {
       "type": ["string"]
     },
+    "node_id": {
+      "type": ["null", "string"]
+    },
     "sha": {
       "type": ["null", "string"],
       "description": "The git commit hash"
@@ -25,72 +28,6 @@
           "url": {
             "type": ["null", "string"],
             "description": "The URL to the parent commit"
-          },
-          "html_url": {
-            "type": ["null", "string"],
-            "description": "The HTML URL to the parent commit"
-          }
-        }
-      }
-    },
-    "files": {
-      "type": [
-        "null",
-        "array"
-      ],
-      "items": {
-        "type": [
-          "null",
-          "object"
-        ],
-        "properties": {
-          "filename": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "additions": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "deletions": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "changes": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "raw_url": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "blob_url": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "patch": {
-            "type": [
-              "null",
-              "string"
-            ]
           }
         }
       }
@@ -102,6 +39,126 @@
     "comments_url": {
       "type": ["null", "string"],
       "description": "The URL to the commit's comments page"
+    },
+    "author": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "login": {
+          "type": ["null", "string"]
+        },
+        "id": {
+          "type": ["null", "number"]
+        },
+        "node_id": {
+          "type": ["null", "string"]
+        },
+        "avatar_url": {
+          "type": ["null", "string"]
+        },
+        "gravatar_url": {
+          "type": ["null", "string"]
+        },
+        "url": {
+          "type": ["null", "string"]
+        },
+        "html_url": {
+          "type": ["null", "string"]
+        },
+        "followers_url": {
+          "type": ["null", "string"]
+        },
+        "following_url": {
+          "type": ["null", "string"]
+        },
+        "gists_url": {
+          "type": ["null", "string"]
+        },
+        "starred_url": {
+          "type": ["null", "string"]
+        },
+        "subscriptions_url": {
+          "type": ["null", "string"]
+        },
+        "organizations_url": {
+          "type": ["null", "string"]
+        },
+        "repos_url": {
+          "type": ["null", "string"]
+        },
+        "events_url": {
+          "type": ["null", "string"]
+        },
+        "received_events_url": {
+          "type": ["null", "string"]
+        },
+        "type_url": {
+          "type": ["null", "string"]
+        },
+        "site_admin": {
+          "type": ["null", "boolean"]
+        }
+      }
+    },
+    "committer": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "login": {
+          "type": ["null", "string"]
+        },
+        "id": {
+          "type": ["null", "number"]
+        },
+        "node_id": {
+          "type": ["null", "string"]
+        },
+        "avatar_url": {
+          "type": ["null", "string"]
+        },
+        "gravatar_url": {
+          "type": ["null", "string"]
+        },
+        "url": {
+          "type": ["null", "string"]
+        },
+        "html_url": {
+          "type": ["null", "string"]
+        },
+        "followers_url": {
+          "type": ["null", "string"]
+        },
+        "following_url": {
+          "type": ["null", "string"]
+        },
+        "gists_url": {
+          "type": ["null", "string"]
+        },
+        "starred_url": {
+          "type": ["null", "string"]
+        },
+        "subscriptions_url": {
+          "type": ["null", "string"]
+        },
+        "organizations_url": {
+          "type": ["null", "string"]
+        },
+        "repos_url": {
+          "type": ["null", "string"]
+        },
+        "events_url": {
+          "type": ["null", "string"]
+        },
+        "received_events_url": {
+          "type": ["null", "string"]
+        },
+        "type_url": {
+          "type": ["null", "string"]
+        },
+        "site_admin": {
+          "type": ["null", "boolean"]
+        }
+      }
     },
     "commit": {
       "type": ["null", "object"],
@@ -173,12 +230,29 @@
             }
           }
         },
+        "verification": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "verified": {
+              "type": ["null", "boolean"]
+            },
+            "reason": {
+              "type": ["null", "string"]
+            },
+            "signature": {
+              "type": ["null", "string"]
+            },
+            "payload": {
+              "type": ["null", "string"]
+            }
+          }
+        },
         "comment_count": {
           "type": ["null", "integer"],
           "description": "The number of comments on the commit"
         }
       }
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/tap_github/schemas/repositories.json
+++ b/tap_github/schemas/repositories.json
@@ -1,0 +1,104 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": ["null", "string"]
+    },
+    "id": {
+      "type": ["null", "integer"]
+    },
+    "url": {
+      "type": ["null", "string"]
+    },
+    "node_id": {
+      "type": ["null", "string"]
+    },
+    "full_name": {
+      "type": ["null", "string"]
+    },
+    "description": {
+      "type": ["null", "string"]
+    },
+    "license": {
+      "type": ["null", "object"],
+      "properties": {
+        "key": {
+          "type": ["null", "string"]
+        },
+        "name": {
+          "type": ["null", "string"]
+        },
+        "spdx_id": {
+          "type": ["null", "string"]
+        },
+        "url": {
+          "type": ["null", "string"]
+        },
+        "node_id": {
+          "type": ["null", "string"]
+        }
+      }
+    },
+    "private": {
+      "type": ["null", "boolean"]
+    },
+    "homepage": {
+      "type": ["null", "string"]
+    },
+    "html_url": {
+      "type": ["null", "string"]
+    },
+    "stargazers_count": {
+      "type": ["null", "integer"]
+    },
+    "forks_count": {
+      "type": ["null", "integer"]
+    },
+    "watchers_count": {
+      "type": ["null", "integer"]
+    },
+    "language": {
+      "type": ["null", "string"]
+    },
+    "pushed_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "topics": {
+      "type": ["null", "array"],
+      "items": {
+          "type": ["null", "string"]
+      }
+    },
+    "owner": {
+      "type": ["null", "object"],
+      "properties": {
+        "login": {
+          "type": ["null", "string"]
+        },
+        "id": {
+          "type": ["null", "integer"]
+        },
+        "node_id": {
+          "type": ["null", "string"]
+        },
+        "avatar_url": {
+          "type": ["null", "string"]
+        },
+        "html_url": {
+          "type": ["null", "string"]
+        },
+        "type": {
+          "type": ["null", "string"]
+        }
+      }
+    },
+    "_sdc_repository": {
+      "type": ["string"]
+    }
+  },
+  "key_properties": [
+    "id"
+  ]
+}


### PR DESCRIPTION
# Description of change
This PR updates the schema for the `commits` stream, based on the current github API docs at https://docs.github.com/en/rest/reference/repos#list-commits and verifying the actual output of the API on some examples.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
