### PR TITLE
Update commits schema based on github api docs

### DIFF
--- a/tap_github/schemas/commits.json
+++ b/tap_github/schemas/commits.json
@@ -5,6 +5,9 @@
     "_sdc_repository": {
       "type": ["string"]
     },
+    "node_id": {
+      "type": ["null", "string"]
+    },
     "sha": {
       "type": ["null", "string"],
       "description": "The git commit hash"
@@ -25,72 +28,6 @@
           "url": {
             "type": ["null", "string"],
             "description": "The URL to the parent commit"
-          },
-          "html_url": {
-            "type": ["null", "string"],
-            "description": "The HTML URL to the parent commit"
-          }
-        }
-      }
-    },
-    "files": {
-      "type": [
-        "null",
-        "array"
-      ],
-      "items": {
-        "type": [
-          "null",
-          "object"
-        ],
-        "properties": {
-          "filename": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "additions": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "deletions": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "changes": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "raw_url": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "blob_url": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "patch": {
-            "type": [
-              "null",
-              "string"
-            ]
           }
         }
       }
@@ -102,6 +39,126 @@
     "comments_url": {
       "type": ["null", "string"],
       "description": "The URL to the commit's comments page"
+    },
+    "author": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "login": {
+          "type": ["null", "string"]
+        },
+        "id": {
+          "type": ["null", "number"]
+        },
+        "node_id": {
+          "type": ["null", "string"]
+        },
+        "avatar_url": {
+          "type": ["null", "string"]
+        },
+        "gravatar_url": {
+          "type": ["null", "string"]
+        },
+        "url": {
+          "type": ["null", "string"]
+        },
+        "html_url": {
+          "type": ["null", "string"]
+        },
+        "followers_url": {
+          "type": ["null", "string"]
+        },
+        "following_url": {
+          "type": ["null", "string"]
+        },
+        "gists_url": {
+          "type": ["null", "string"]
+        },
+        "starred_url": {
+          "type": ["null", "string"]
+        },
+        "subscriptions_url": {
+          "type": ["null", "string"]
+        },
+        "organizations_url": {
+          "type": ["null", "string"]
+        },
+        "repos_url": {
+          "type": ["null", "string"]
+        },
+        "events_url": {
+          "type": ["null", "string"]
+        },
+        "received_events_url": {
+          "type": ["null", "string"]
+        },
+        "type_url": {
+          "type": ["null", "string"]
+        },
+        "site_admin": {
+          "type": ["null", "boolean"]
+        }
+      }
+    },
+    "committer": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "login": {
+          "type": ["null", "string"]
+        },
+        "id": {
+          "type": ["null", "number"]
+        },
+        "node_id": {
+          "type": ["null", "string"]
+        },
+        "avatar_url": {
+          "type": ["null", "string"]
+        },
+        "gravatar_url": {
+          "type": ["null", "string"]
+        },
+        "url": {
+          "type": ["null", "string"]
+        },
+        "html_url": {
+          "type": ["null", "string"]
+        },
+        "followers_url": {
+          "type": ["null", "string"]
+        },
+        "following_url": {
+          "type": ["null", "string"]
+        },
+        "gists_url": {
+          "type": ["null", "string"]
+        },
+        "starred_url": {
+          "type": ["null", "string"]
+        },
+        "subscriptions_url": {
+          "type": ["null", "string"]
+        },
+        "organizations_url": {
+          "type": ["null", "string"]
+        },
+        "repos_url": {
+          "type": ["null", "string"]
+        },
+        "events_url": {
+          "type": ["null", "string"]
+        },
+        "received_events_url": {
+          "type": ["null", "string"]
+        },
+        "type_url": {
+          "type": ["null", "string"]
+        },
+        "site_admin": {
+          "type": ["null", "boolean"]
+        }
+      }
     },
     "commit": {
       "type": ["null", "object"],
@@ -173,12 +230,29 @@
             }
           }
         },
+        "verification": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "verified": {
+              "type": ["null", "boolean"]
+            },
+            "reason": {
+              "type": ["null", "string"]
+            },
+            "signature": {
+              "type": ["null", "string"]
+            },
+            "payload": {
+              "type": ["null", "string"]
+            }
+          }
+        },
         "comment_count": {
           "type": ["null", "integer"],
           "description": "The number of comments on the commit"
         }
       }
     }
-  },
-  "additionalProperties": false
+  }
 }


### PR DESCRIPTION
# Description of change
This PR updates the schema for the `commits` stream, based on the current github api docs at https://docs.github.com/en/rest/reference/repos#list-commits and double checking the actual output of the API on a few examples.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
