### PR TITLE
Improve rate limiting and retry logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(name='tap-github',
       py_modules=['tap_github'],
       install_requires=[
           'singer-python==5.12.1',
-          'requests==2.20.0'
+          'requests==2.20.0',
+          'backoff==1.8.0'
       ],
       extras_require={
           'dev': [

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1102,10 +1102,12 @@ def do_sync(config, state, catalog):
 def main():
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
+    # get optional config key `max_sleep_seconds`
     config_max_sleep = args.config.get('max_sleep_seconds')
 
-    global MAX_SLEEP_SECONDS 
-    MAX_SLEEP_SECONDS = config_max_sleep if config_max_sleep else MAX_SLEEP_SECONDS
+    # set global `MAX_SLEEP_SECONDS` for rate_throttling function or use default
+    global MAX_SLEEP_SECONDS
+    MAX_SLEEP_SECONDS = config_max_sleep if config_max_sleep else DEFAULT_SLEEP_SECONDS
 
     if args.discover:
         do_discover(args.config)

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -42,6 +42,9 @@ KEY_PROPERTIES = {
     'team_memberships': ['url']
 }
 
+DEFAULT_SLEEP_SECONDS = 600
+MAX_SLEEP_SECONDS = DEFAULT_SLEEP_SECONDS
+
 class GithubException(Exception):
     pass
 
@@ -192,7 +195,7 @@ def rate_throttling(response):
     if int(response.headers['X-RateLimit-Remaining']) == 0:
         seconds_to_sleep = calculate_seconds(int(response.headers['X-RateLimit-Reset']))
 
-        if seconds_to_sleep > 600:
+        if seconds_to_sleep > MAX_SLEEP_SECONDS:
             message = "API rate limit exceeded, please try after {} seconds.".format(seconds_to_sleep)
             raise RateLimitExceeded(message) from None
 
@@ -1098,6 +1101,11 @@ def do_sync(config, state, catalog):
 @singer.utils.handle_top_exception(logger)
 def main():
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
+
+    config_max_sleep = args.config.get('max_sleep_seconds')
+
+    global MAX_SLEEP_SECONDS 
+    MAX_SLEEP_SECONDS = config_max_sleep if config_max_sleep else MAX_SLEEP_SECONDS
 
     if args.discover:
         do_discover(args.config)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -31,7 +31,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.BadRequestException as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
+            self.assertEqual(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
 
     def test_400_error(self, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True)
@@ -39,7 +39,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.BadRequestException as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
+            self.assertEqual(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
     
     def test_401_error(self, mocked_request):
         mocked_request.return_value = get_response(401, raise_error = True)
@@ -47,7 +47,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.BadCredentialsException as e:
-            self.assertEquals(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
+            self.assertEqual(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
     
     def test_403_error(self, mocked_request):
         mocked_request.return_value = get_response(403, raise_error = True)
@@ -55,7 +55,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.AuthException as e:
-            self.assertEquals(str(e), "HTTP-error-code: 403, Error: User doesn't have permission to access the resource.")
+            self.assertEqual(str(e), "HTTP-error-code: 403, Error: User doesn't have permission to access the resource.")
     
     def test_404_error(self, mocked_request):
         json = {"message": "Not Found", "documentation_url": "https:/docs.github.com/"}
@@ -64,7 +64,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.NotFoundException as e:
-            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Please refer '{}' for more details.".format(json.get("documentation_url")))
+            self.assertEqual(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Please refer '{}' for more details.".format(json.get("documentation_url")))
 
     def test_404_error_for_teams(self, mocked_request):
         json = {"message": "Not Found", "documentation_url": "https:/docs.github.com/"}
@@ -72,7 +72,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.raise_for_error(get_response(404, json = json, raise_error = True), "teams")
         except tap_github.NotFoundException as e:
-            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found or it is a personal account repository. Please refer '{}' for more details.".format(json.get("documentation_url")))
+            self.assertEqual(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found or it is a personal account repository. Please refer '{}' for more details.".format(json.get("documentation_url")))
 
     def test_500_error(self, mocked_request):
         mocked_request.return_value = get_response(500, raise_error = True)
@@ -80,7 +80,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.InternalServerError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 500, Error: An error has occurred at Github's end.")
+            self.assertEqual(str(e), "HTTP-error-code: 500, Error: An error has occurred at Github's end.")
 
     def test_301_error(self, mocked_request):
         mocked_request.return_value = get_response(301, raise_error = True)
@@ -88,7 +88,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.MovedPermanentlyError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 301, Error: The resource you are looking for is moved to another URL.")
+            self.assertEqual(str(e), "HTTP-error-code: 301, Error: The resource you are looking for is moved to another URL.")
 
     def test_304_error(self, mocked_request):
         mocked_request.return_value = get_response(304, raise_error = True)
@@ -96,7 +96,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.NotModifiedError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 304, Error: The requested resource has not been modified since the last time you accessed it.")
+            self.assertEqual(str(e), "HTTP-error-code: 304, Error: The requested resource has not been modified since the last time you accessed it.")
 
     def test_422_error(self, mocked_request):
         mocked_request.return_value = get_response(422, raise_error = True)
@@ -104,7 +104,7 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.UnprocessableError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 422, Error: The request was not able to process right now.")
+            self.assertEqual(str(e), "HTTP-error-code: 422, Error: The request was not able to process right now.")
 
     def test_409_error(self, mocked_request):
         mocked_request.return_value = get_response(409, raise_error = True)
@@ -112,11 +112,11 @@ class TestExceptionHandling(unittest.TestCase):
         try:
             tap_github.authed_get("", "")
         except tap_github.ConflictError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 409, Error: The request could not be completed due to a conflict with the current state of the server.")
+            self.assertEqual(str(e), "HTTP-error-code: 409, Error: The request could not be completed due to a conflict with the current state of the server.")
 
     def test_200_success(self, mocked_request):
         json = {"key": "value"}
         mocked_request.return_value = get_response(200, json)
 
         resp = tap_github.authed_get("", "")
-        self.assertEquals(json, resp.json())
+        self.assertEqual(json, resp.json())

--- a/tests/unittests/test_formatting_dates.py
+++ b/tests/unittests/test_formatting_dates.py
@@ -91,7 +91,7 @@ class TestRateLimit(unittest.TestCase):
 
         final_state = tap_github.get_all_issue_milestones({}, repo_path, init_state, {}, "")
         # as we will get 0 records, initial and final bookmark will be same
-        self.assertEquals(init_bookmark, final_state["bookmarks"][repo_path]["issue_milestones"]["since"])
+        self.assertEqual(init_bookmark, final_state["bookmarks"][repo_path]["issue_milestones"]["since"])
 
     @mock.patch("singer.write_record")
     def test_data_containing_both_values(self, mocked_write_record, mocked_request):
@@ -117,4 +117,4 @@ class TestRateLimit(unittest.TestCase):
         # as we will get 2 record, final bookmark will be greater than initial bookmark
         self.assertGreater(last_bookmark, init_bookmark)
         # as we will get 2 record, write_records will also be called 2 times
-        self.assertEquals(mocked_write_record.call_count, 2)
+        self.assertEqual(mocked_write_record.call_count, 2)

--- a/tests/unittests/test_key_error.py
+++ b/tests/unittests/test_key_error.py
@@ -37,7 +37,7 @@ class TestKeyErrorSlug(unittest.TestCase):
             "metadata": {"inclusion": "available"}
         }]
         tap_github.get_all_teams(schemas, "tap-github", {}, mdata, "")
-        self.assertEquals(mocked_team_members.call_count, 1)
+        self.assertEqual(mocked_team_members.call_count, 1)
 
     @mock.patch("tap_github.__init__.get_all_team_members")
     def test_slug_sub_stream_not_selected_slug_selected(self, mocked_team_members, mocked_request):
@@ -60,7 +60,7 @@ class TestKeyErrorSlug(unittest.TestCase):
             "metadata": {"inclusion": "available"}
         }]
         tap_github.get_all_teams(schemas, "tap-github", {}, mdata, "")
-        self.assertEquals(mocked_team_members.call_count, 0)
+        self.assertEqual(mocked_team_members.call_count, 0)
 
     @mock.patch("tap_github.__init__.get_all_team_members")
     def test_slug_sub_stream_selected_slug_not_selected(self, mocked_team_members, mocked_request):
@@ -83,7 +83,7 @@ class TestKeyErrorSlug(unittest.TestCase):
             "metadata": {"inclusion": "available"}
         }]
         tap_github.get_all_teams(schemas, "tap-github", {}, mdata, "")
-        self.assertEquals(mocked_team_members.call_count, 1)
+        self.assertEqual(mocked_team_members.call_count, 1)
 
     @mock.patch("tap_github.__init__.get_all_team_members")
     def test_slug_sub_stream_not_selected_slug_not_selected(self, mocked_team_members, mocked_request):
@@ -106,7 +106,7 @@ class TestKeyErrorSlug(unittest.TestCase):
             "metadata": {"inclusion": "available"}
         }]
         tap_github.get_all_teams(schemas, "tap-github", {}, mdata, "")
-        self.assertEquals(mocked_team_members.call_count, 0)
+        self.assertEqual(mocked_team_members.call_count, 0)
 
 @mock.patch("tap_github.__init__.authed_get_all_pages")
 class TestKeyErrorUser(unittest.TestCase):
@@ -132,7 +132,7 @@ class TestKeyErrorUser(unittest.TestCase):
           "metadata": {"inclusion": "available"}
         }]
         tap_github.get_all_stargazers(schemas, "tap-github", {}, mdata, "")
-        self.assertEquals(mocked_write_records.call_count, 1)
+        self.assertEqual(mocked_write_records.call_count, 1)
 
     @mock.patch("singer.write_record")
     def test_user_selected_in_stargazers(self, mocked_write_records, mocked_request):
@@ -155,4 +155,4 @@ class TestKeyErrorUser(unittest.TestCase):
           "metadata": {"inclusion": "available"}
         }]
         tap_github.get_all_stargazers(schemas, "tap-github", {}, mdata, "")
-        self.assertEquals(mocked_write_records.call_count, 1)
+        self.assertEqual(mocked_write_records.call_count, 1)

--- a/tests/unittests/test_rate_limit.py
+++ b/tests/unittests/test_rate_limit.py
@@ -36,7 +36,7 @@ class TestRateLimit(unittest.TestCase):
         try:
             tap_github.rate_throttling(resp)
         except tap_github.RateLimitExceeded as e:
-            self.assertEquals(str(e), "API rate limit exceeded, please try after 601 seconds.")
+            self.assertEqual(str(e), "API rate limit exceeded, please try after 601 seconds.")
 
 
     def test_rate_limit_not_exceeded(self, mocked_sleep):

--- a/tests/unittests/test_start_date_bookmark.py
+++ b/tests/unittests/test_start_date_bookmark.py
@@ -12,7 +12,7 @@ class TestBookmarkStartDate(unittest.TestCase):
         bookmark_key = 'since'
         expected_bookmark_value  = None
 
-        self.assertEquals(expected_bookmark_value, tap_github.get_bookmark('', '', '', bookmark_key, start_date))
+        self.assertEqual(expected_bookmark_value, tap_github.get_bookmark('', '', '', bookmark_key, start_date))
 
     def test_no_bookmark_yes_start_date(self, mocked_get_bookmark):
         # Start date is present and bookmark is not present then start date should be return.
@@ -21,7 +21,7 @@ class TestBookmarkStartDate(unittest.TestCase):
         bookmark_key = 'since'
         expected_bookmark_value  = '2021-04-01T00:00:00.000000Z'
 
-        self.assertEquals(expected_bookmark_value, tap_github.get_bookmark('', '', '', bookmark_key, start_date))
+        self.assertEqual(expected_bookmark_value, tap_github.get_bookmark('', '', '', bookmark_key, start_date))
 
     def test_yes_bookmark_yes_start_date(self, mocked_get_bookmark):
         # Start date and bookmark both are present then bookmark should be return.
@@ -30,7 +30,7 @@ class TestBookmarkStartDate(unittest.TestCase):
         bookmark_key = 'since'
         expected_bookmark_value  = '2021-05-01T00:00:00.000000Z'
 
-        self.assertEquals(expected_bookmark_value, tap_github.get_bookmark('', '', '', bookmark_key, start_date))
+        self.assertEqual(expected_bookmark_value, tap_github.get_bookmark('', '', '', bookmark_key, start_date))
 
     def test_yes_bookmark_no_start_date(self, mocked_get_bookmark):
         # Start date is not present and bookmark is present then bookmark should be return.
@@ -39,4 +39,4 @@ class TestBookmarkStartDate(unittest.TestCase):
         bookmark_key = 'since'
         expected_bookmark_value  = '2021-05-01T00:00:00.000000Z'
 
-        self.assertEquals(expected_bookmark_value, tap_github.get_bookmark('', '', '', bookmark_key, start_date))
+        self.assertEqual(expected_bookmark_value, tap_github.get_bookmark('', '', '', bookmark_key, start_date))

--- a/tests/unittests/test_sub_streams_selection.py
+++ b/tests/unittests/test_sub_streams_selection.py
@@ -12,7 +12,7 @@ class TestSubStreamSelection(unittest.TestCase):
         try:
             tap_github.validate_dependencies(selected_streams)
         except tap_github.DependencyException as e:
-            self.assertEquals(str(e), "Unable to extract 'reviews' data, to receive 'reviews' data, you also need to select 'pull_requests'. Unable to extract 'pr_commits' data, to receive 'pr_commits' data, you also need to select 'pull_requests'.")
+            self.assertEqual(str(e), "Unable to extract 'reviews' data, to receive 'reviews' data, you also need to select 'pull_requests'. Unable to extract 'pr_commits' data, to receive 'pr_commits' data, you also need to select 'pull_requests'.")
 
     def test_teams_sub_streams_selected(self):
         selected_streams = ["teams", "team_members"]
@@ -23,7 +23,7 @@ class TestSubStreamSelection(unittest.TestCase):
         try:
             tap_github.validate_dependencies(selected_streams)
         except tap_github.DependencyException as e:
-            self.assertEquals(str(e), "Unable to extract 'team_members' data, to receive 'team_members' data, you also need to select 'teams'.")
+            self.assertEqual(str(e), "Unable to extract 'team_members' data, to receive 'team_members' data, you also need to select 'teams'.")
 
     def test_projects_sub_streams_selected(self):
         selected_streams = ["projects", "project_cards"]
@@ -34,7 +34,7 @@ class TestSubStreamSelection(unittest.TestCase):
         try:
             tap_github.validate_dependencies(selected_streams)
         except tap_github.DependencyException as e:
-            self.assertEquals(str(e), "Unable to extract 'project_columns' data, to receive 'project_columns' data, you also need to select 'projects'.")
+            self.assertEqual(str(e), "Unable to extract 'project_columns' data, to receive 'project_columns' data, you also need to select 'projects'.")
 
     def test_mixed_streams_positive(self):
         selected_streams = ["pull_requests", "reviews", "collaborators", "team_members", "stargazers", "projects", "teams", "project_cards"]
@@ -45,4 +45,4 @@ class TestSubStreamSelection(unittest.TestCase):
         try:
             tap_github.validate_dependencies(selected_streams)
         except tap_github.DependencyException as e:
-            self.assertEquals(str(e), "Unable to extract 'review_comments' data, to receive 'review_comments' data, you also need to select 'pull_requests'.")
+            self.assertEqual(str(e), "Unable to extract 'review_comments' data, to receive 'review_comments' data, you also need to select 'pull_requests'.")

--- a/tests/unittests/test_verify_access.py
+++ b/tests/unittests/test_verify_access.py
@@ -33,7 +33,7 @@ class TestCredentials(unittest.TestCase):
         try:
             tap_github.verify_repo_access("", "repo")
         except tap_github.NotFoundException as e:
-            self.assertEquals(str(e), "HTTP-error-code: 404, Error: Please check the repository name 'repo' or you do not have sufficient permissions to access this repository.")
+            self.assertEqual(str(e), "HTTP-error-code: 404, Error: Please check the repository name 'repo' or you do not have sufficient permissions to access this repository.")
 
     def test_repo_bad_request(self, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True)
@@ -41,7 +41,7 @@ class TestCredentials(unittest.TestCase):
         try:
             tap_github.verify_repo_access("", "repo")
         except tap_github.BadRequestException as e:
-            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
+            self.assertEqual(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
 
     def test_repo_bad_creds(self, mocked_request):
         json = {"message": "Bad credentials", "documentation_url": "https://docs.github.com/"}
@@ -50,7 +50,7 @@ class TestCredentials(unittest.TestCase):
         try:
             tap_github.verify_repo_access("", "repo")
         except tap_github.BadCredentialsException as e:
-            self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(json))
+            self.assertEqual(str(e), "HTTP-error-code: 401, Error: {}".format(json))
 
     @mock.patch("tap_github.get_catalog")
     def test_discover_valid_creds(self, mocked_get_catalog, mocked_request):
@@ -70,7 +70,7 @@ class TestCredentials(unittest.TestCase):
         try:
             tap_github.do_discover({"access_token": "access_token", "repository": "org/repo"})
         except tap_github.NotFoundException as e:
-                self.assertEquals(str(e), "HTTP-error-code: 404, Error: Please check the repository name 'org/repo' or you do not have sufficient permissions to access this repository.")
+                self.assertEqual(str(e), "HTTP-error-code: 404, Error: Please check the repository name 'org/repo' or you do not have sufficient permissions to access this repository.")
         self.assertEqual(mocked_get_catalog.call_count, 0)
 
     @mock.patch("tap_github.get_catalog")
@@ -81,7 +81,7 @@ class TestCredentials(unittest.TestCase):
         try:
             tap_github.do_discover({"access_token": "access_token", "repository": "org/repo"})
         except tap_github.BadRequestException as e:
-                self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
+                self.assertEqual(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
         self.assertEqual(mocked_get_catalog.call_count, 0)
 
     @mock.patch("tap_github.get_catalog")
@@ -93,7 +93,7 @@ class TestCredentials(unittest.TestCase):
         try:
             tap_github.do_discover({"access_token": "access_token", "repository": "org/repo"})
         except tap_github.BadCredentialsException as e:
-                self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(json))
+                self.assertEqual(str(e), "HTTP-error-code: 401, Error: {}".format(json))
         self.assertEqual(mocked_get_catalog.call_count, 0)
 
     @mock.patch("tap_github.get_catalog")
@@ -105,7 +105,7 @@ class TestCredentials(unittest.TestCase):
         try:
             tap_github.do_discover({"access_token": "access_token", "repository": "org/repo"})
         except tap_github.AuthException as e:
-                self.assertEquals(str(e), "HTTP-error-code: 403, Error: {}".format(json))
+                self.assertEqual(str(e), "HTTP-error-code: 403, Error: {}".format(json))
         self.assertEqual(mocked_get_catalog.call_count, 0)
 
 
@@ -122,5 +122,5 @@ class TestRepoCallCount(unittest.TestCase):
         config = {"access_token": "access_token", "repository": "org1/repo1 org1/repo2 org2/repo1"}
         tap_github.verify_access_for_repo(config)
 
-        self.assertEquals(mocked_logger_info.call_count, 3)
-        self.assertEquals(mocked_repo.call_count, 3)
+        self.assertEqual(mocked_logger_info.call_count, 3)
+        self.assertEqual(mocked_repo.call_count, 3)


### PR DESCRIPTION
# Description of change
- added backoff retry to `authed_get` method as per [TDL-15621](https://jira.talendforge.org/browse/TDL-15621)
- replaced deprecated `assertEquals` method with `assertEqual` in unit tests

# Manual QA steps
 - rap tap locally
 - ran unit tests
 - ran against `singer-check-tap` and `target-stitch --dry-run`
 - ran tap-tester locally
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
