### PR TITLE
Resolve Start Date test case failure

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -23,6 +23,7 @@ class TestGithubBase(unittest.TestCase):
     }
     START_DATE = ""
     FULL_TABLE_SUB_STREAMS = ['reviews', 'review_comments', 'pr_commits', 'team_members', 'team_memberships']
+    OBEYS_START_DATE = "obey-start-date"
 
     def setUp(self):
         missing_envs = [x for x in [
@@ -94,104 +95,126 @@ class TestGithubBase(unittest.TestCase):
             "assignees": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.FULL,
+                self.OBEYS_START_DATE: False
             },
             "collaborators": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.FULL,
+                self.OBEYS_START_DATE: False
             },
             "comments": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "commit_comments": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "commits": {
                 self.PRIMARY_KEYS: {"sha"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "events": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"created_at"}
+                self.BOOKMARK: {"created_at"},
+                self.OBEYS_START_DATE: True
             },
             "issue_labels": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.FULL,
+                self.OBEYS_START_DATE: False
             },
             "issue_milestones": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"due_on"}
+                self.BOOKMARK: {"due_on"},
+                self.OBEYS_START_DATE: True
             },
             "issue_events": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"created_at"}
+                self.BOOKMARK: {"created_at"},
+                self.OBEYS_START_DATE: True
             },
             "issues": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "pr_commits": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "project_cards": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "project_columns": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "projects": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "pull_requests": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "releases": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.FULL,
+                self.OBEYS_START_DATE: False
             },
             "review_comments": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "reviews": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.BOOKMARK: {"updated_at"}
+                self.BOOKMARK: {"updated_at"},
+                self.OBEYS_START_DATE: True
             },
             "stargazers": {
                 self.PRIMARY_KEYS: {"user_id"},
                 self.REPLICATION_METHOD: self.FULL,
+                self.OBEYS_START_DATE: False
             },
             "team_members": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.FULL,
+                self.OBEYS_START_DATE: False
             },
             "team_memberships": {
                 self.PRIMARY_KEYS: {"url"},
                 self.REPLICATION_METHOD: self.FULL,
+                self.OBEYS_START_DATE: False
             },
             "teams": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.FULL,
+                self.OBEYS_START_DATE: False
             }
         }
 

--- a/tests/test_github_start_date.py
+++ b/tests/test_github_start_date.py
@@ -16,6 +16,8 @@ class GithubStartDateTest(TestGithubBase):
         return "tap_tester_github_start_date_test"
 
     def test_run(self):
+        # run the test for all the streams excluding 'events' stream
+        # as for 'events' stream we have to use dynamic dates
         self.run_test('2020-04-01T00:00:00Z', '2021-06-10T00:00:00Z', self.expected_streams() - {'events'})
 
         # As per the Documentation: https://docs.github.com/en/rest/reference/activity#events
@@ -26,6 +28,7 @@ class GithubStartDateTest(TestGithubBase):
         today = datetime.today()
         date_1 = datetime.strftime(today - timedelta(days=90), "%Y-%m-%dT00:00:00Z")
         date_2 = datetime.strftime(today - timedelta(days=30), "%Y-%m-%dT00:00:00Z")
+        # run the test for 'events' stream
         self.run_test(date_1, date_2, {'events'})
 
     def run_test(self, date_1, date_2, streams):

--- a/tests/test_github_start_date.py
+++ b/tests/test_github_start_date.py
@@ -39,8 +39,8 @@ class GithubStartDateTest(TestGithubBase):
         # the 'events' of past 90 days will only be returned
         # if there are no events in past 90 days, then there will be '304 Not Modified' error
         today = datetime.today()
-        date_1 = datetime.strftime(today - timedelta(days=1), "%Y-%m-%dT00:00:00Z")
-        date_2 = datetime.strftime(today, "%Y-%m-%dT00:00:00Z")
+        date_1 = datetime.strftime(today - timedelta(days=4), "%Y-%m-%dT00:00:00Z")
+        date_2 = datetime.strftime(today - timedelta(days=1), "%Y-%m-%dT00:00:00Z")
         # run the test for 'events' stream
         self.run_test(date_1, date_2, {'events'})
 

--- a/tests/test_github_start_date.py
+++ b/tests/test_github_start_date.py
@@ -121,6 +121,7 @@ class GithubStartDateTest(TestGithubBase):
                 # expected values
                 expected_primary_keys = self.expected_primary_keys()[stream]
                 expected_bookmark_keys = self.expected_bookmark_keys()[stream]
+                expected_metadata = self.expected_metadata()[stream]
 
                 # collect information for assertions from syncs 1 & 2 base on expected values
                 record_count_sync_1 = record_count_by_stream_1.get(stream, 0)
@@ -135,7 +136,7 @@ class GithubStartDateTest(TestGithubBase):
                 primary_keys_sync_1 = set(primary_keys_list_1)
                 primary_keys_sync_2 = set(primary_keys_list_2)
 
-                if self.is_incremental(stream):
+                if expected_metadata.get(self.OBEYS_START_DATE):
                     
                     # Sub stream fetch all data for records of related incremental super stream.
                     # Data of commit doesn't contain created_at or updated_at field. 


### PR DESCRIPTION
# Description of change
Resolve Start Date test case failure
- For 'events' stream the API will only fetch the data of the past 90 days only.
- Use API to generate 'events' data and made start dates dynamic ie. 1st start date `today() - 1 days` and 2nd start date `today() - 4 days`.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
