### PR TITLE
TDL-16349: Add request timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,17 @@ jobs:
             source /usr/local/share/virtualenvs/tap-github/bin/activate
             pylint tap_github --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace'
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-github/bin/activate
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_github --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
+      - run:
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This tap:
     Create a JSON file containing the start date, access token you just created
     and the path to one or multiple repositories that you want to extract data from. Each repo path should be space delimited. The repo path is relative to
     `https://github.com/`. For example the path for this repository is
-    `singer-io/tap-github`. 
+    `singer-io/tap-github`. You can also add request timeout to set the timeout for requests which is an optional parameter with default value of 300 seconds.
 
     ```json
     {"access_token": "your-access-token",

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ This tap:
     ```json
     {"access_token": "your-access-token",
      "repository": "singer-io/tap-github singer-io/getting-started",
-     "start_date": "2021-01-01T00:00:00Z"}
+     "start_date": "2021-01-01T00:00:00Z",
+     "request_timeout": 300}
     ```
 4. Run the tap in discovery mode to get properties.json file
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,5 +1,6 @@
 {
     "access_token": "abcdefghijklmnopqrstuvwxyz1234567890ABCD",
     "repository": "singer-io/target-stitch",
-    "start_date": "2021-01-01T00:00:00Z"
+    "start_date": "2021-01-01T00:00:00Z",
+    "request_timeout": 300
 }

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -7,11 +7,15 @@ import requests
 import singer
 import singer.bookmarks as bookmarks
 import singer.metrics as metrics
+import backoff
 
 from singer import metadata
 
 session = requests.Session()
 logger = singer.get_logger()
+
+# set default timeout of 300 seconds
+REQUEST_TIMEOUT = 300
 
 REQUIRED_CONFIG_KEYS = ['start_date', 'access_token', 'repository']
 
@@ -199,10 +203,14 @@ def rate_throttling(response):
         time.sleep(seconds_to_sleep)
 
 # pylint: disable=dangerous-default-value
+# during 'Timeout' error there is also possibility of 'ConnectionError',
+# hence added backoff for 'ConnectionError' too.
+@backoff.on_exception(backoff.expo, requests.Timeout, max_tries=5, factor=2)
+@backoff.on_exception(backoff.expo, requests.ConnectionError, max_tries=5, factor=2)
 def authed_get(source, url, headers={}):
     with metrics.http_request_timer(source) as timer:
         session.headers.update(headers)
-        resp = session.request(method='get', url=url)
+        resp = session.request(method='get', url=url, timeout=get_request_timeout())
         if resp.status_code != 200:
             raise_for_error(resp, source)
         timer.tags[metrics.Tag.http_status_code] = resp.status_code
@@ -1009,6 +1017,20 @@ def get_stream_from_catalog(stream_id, catalog):
         if stream['tap_stream_id'] == stream_id:
             return stream
     return None
+
+# return the 'timeout'
+def get_request_timeout():
+    args = singer.utils.parse_args([])
+    # get the value of request timeout from config
+    config_request_timeout = args.config.get('request_timeout')
+
+    if config_request_timeout and float(config_request_timeout):
+        request_timeout = float(config_request_timeout)
+        # return the timeout from config
+        return request_timeout
+
+    # return default timeout
+    return REQUEST_TIMEOUT
 
 SYNC_FUNCTIONS = {
     'commits': get_all_commits,

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -205,8 +205,7 @@ def rate_throttling(response):
 # pylint: disable=dangerous-default-value
 # during 'Timeout' error there is also possibility of 'ConnectionError',
 # hence added backoff for 'ConnectionError' too.
-@backoff.on_exception(backoff.expo, requests.Timeout, max_tries=5, factor=2)
-@backoff.on_exception(backoff.expo, requests.ConnectionError, max_tries=5, factor=2)
+@backoff.on_exception(backoff.expo, (requests.Timeout, requests.ConnectionError), max_tries=5, factor=2)
 def authed_get(source, url, headers={}):
     with metrics.http_request_timer(source) as timer:
         session.headers.update(headers)

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1023,10 +1023,10 @@ def get_request_timeout():
     # get the value of request timeout from config
     config_request_timeout = args.config.get('request_timeout')
 
+    # only return the timeout value if it is passed in the config and the value is not 0, "0" or ""
     if config_request_timeout and float(config_request_timeout):
-        request_timeout = float(config_request_timeout)
         # return the timeout from config
-        return request_timeout
+        return float(config_request_timeout)
 
     # return default timeout
     return REQUEST_TIMEOUT

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -24,8 +24,9 @@ def get_response(status_code, json={}, raise_error=False, content=None):
     return Mockresponse(status_code, json, raise_error, content=content)
 
 @mock.patch("requests.Session.request")
+@mock.patch("singer.utils.parse_args")
 class TestExceptionHandling(unittest.TestCase):
-    def test_zero_content_length(self, mocked_request):
+    def test_zero_content_length(self, mocked_parse_args, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True, content='')
 
         try:
@@ -33,7 +34,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.BadRequestException as e:
             self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
 
-    def test_400_error(self, mocked_request):
+    def test_400_error(self, mocked_parse_args, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True)
         
         try:
@@ -41,7 +42,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.BadRequestException as e:
             self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
     
-    def test_401_error(self, mocked_request):
+    def test_401_error(self, mocked_parse_args, mocked_request):
         mocked_request.return_value = get_response(401, raise_error = True)
         
         try:
@@ -49,7 +50,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.BadCredentialsException as e:
             self.assertEquals(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
     
-    def test_403_error(self, mocked_request):
+    def test_403_error(self, mocked_parse_args, mocked_request):
         mocked_request.return_value = get_response(403, raise_error = True)
         
         try:
@@ -57,7 +58,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.AuthException as e:
             self.assertEquals(str(e), "HTTP-error-code: 403, Error: User doesn't have permission to access the resource.")
     
-    def test_404_error(self, mocked_request):
+    def test_404_error(self, mocked_parse_args, mocked_request):
         json = {"message": "Not Found", "documentation_url": "https:/docs.github.com/"}
         mocked_request.return_value = get_response(404, json = json, raise_error = True)
 
@@ -66,7 +67,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.NotFoundException as e:
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Please refer '{}' for more details.".format(json.get("documentation_url")))
 
-    def test_404_error_for_teams(self, mocked_request):
+    def test_404_error_for_teams(self, mocked_parse_args, mocked_request):
         json = {"message": "Not Found", "documentation_url": "https:/docs.github.com/"}
 
         try:
@@ -74,7 +75,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.NotFoundException as e:
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found or it is a personal account repository. Please refer '{}' for more details.".format(json.get("documentation_url")))
 
-    def test_500_error(self, mocked_request):
+    def test_500_error(self, mocked_parse_args, mocked_request):
         mocked_request.return_value = get_response(500, raise_error = True)
 
         try:
@@ -82,7 +83,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.InternalServerError as e:
             self.assertEquals(str(e), "HTTP-error-code: 500, Error: An error has occurred at Github's end.")
 
-    def test_301_error(self, mocked_request):
+    def test_301_error(self, mocked_parse_args, mocked_request):
         mocked_request.return_value = get_response(301, raise_error = True)
 
         try:
@@ -90,7 +91,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.MovedPermanentlyError as e:
             self.assertEquals(str(e), "HTTP-error-code: 301, Error: The resource you are looking for is moved to another URL.")
 
-    def test_304_error(self, mocked_request):
+    def test_304_error(self, mocked_parse_args, mocked_request):
         mocked_request.return_value = get_response(304, raise_error = True)
 
         try:
@@ -98,7 +99,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.NotModifiedError as e:
             self.assertEquals(str(e), "HTTP-error-code: 304, Error: The requested resource has not been modified since the last time you accessed it.")
 
-    def test_422_error(self, mocked_request):
+    def test_422_error(self, mocked_parse_args, mocked_request):
         mocked_request.return_value = get_response(422, raise_error = True)
 
         try:
@@ -106,7 +107,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.UnprocessableError as e:
             self.assertEquals(str(e), "HTTP-error-code: 422, Error: The request was not able to process right now.")
 
-    def test_409_error(self, mocked_request):
+    def test_409_error(self, mocked_parse_args, mocked_request):
         mocked_request.return_value = get_response(409, raise_error = True)
 
         try:
@@ -114,7 +115,7 @@ class TestExceptionHandling(unittest.TestCase):
         except tap_github.ConflictError as e:
             self.assertEquals(str(e), "HTTP-error-code: 409, Error: The request could not be completed due to a conflict with the current state of the server.")
 
-    def test_200_success(self, mocked_request):
+    def test_200_success(self, mocked_parse_args, mocked_request):
         json = {"key": "value"}
         mocked_request.return_value = get_response(200, json)
 

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -1,0 +1,196 @@
+import unittest
+from unittest import mock
+import tap_github.__init__ as tap_github
+import requests
+
+class Mockresponse:
+    def __init__(self, status_code, json, raise_error, headers={'X-RateLimit-Remaining': 1}, text=None, content=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.text = json
+        self.headers = headers
+        self.content = content if content is not None else 'github'
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("Sample message")
+
+    def json(self):
+        return self.text
+
+class MockParseArgs:
+    config = {}
+    def __init__(self, config):
+        self.config = config
+
+def get_args(config):
+    return MockParseArgs(config)
+
+def get_response(status_code, json={}, raise_error=False, content=None):
+    return Mockresponse(status_code, json, raise_error, content=content)
+
+@mock.patch("time.sleep")
+@mock.patch("requests.Session.request")
+@mock.patch("singer.utils.parse_args")
+class TestTimeoutValue(unittest.TestCase):
+    """
+        Test case to verify the timeout value is set as expected
+    """
+
+    def test_timeout_value_in_config(self, mocked_parse_args, mocked_request, mocked_sleep):
+        json = {"key": "value"}
+        # mock response
+        mocked_request.return_value = get_response(200, json)
+
+        mock_config = {"request_timeout": 100}
+        # mock parse args
+        mocked_parse_args.return_value = get_args(mock_config)
+
+        # get the timeout value for assertion
+        timeout = tap_github.get_request_timeout()
+        # function call
+        tap_github.authed_get("test_source", "")
+
+        # verify that we got expected timeout value
+        self.assertEquals(100.0, timeout)
+        # verify that the request was called with expected timeout value
+        mocked_request.assert_called_with(method='get', url='', timeout=100.0)
+
+    def test_timeout_value_not_in_config(self, mocked_parse_args, mocked_request, mocked_sleep):
+        json = {"key": "value"}
+        # mock response
+        mocked_request.return_value = get_response(200, json)
+
+        mock_config = {}
+        # mock parse args
+        mocked_parse_args.return_value = get_args(mock_config)
+
+        # get the timeout value for assertion
+        timeout = tap_github.get_request_timeout()
+        # function call
+        tap_github.authed_get("test_source", "")
+
+        # verify that we got expected timeout value
+        self.assertEquals(300.0, timeout)
+        # verify that the request was called with expected timeout value
+        mocked_request.assert_called_with(method='get', url='', timeout=300.0)
+
+    def test_timeout_string_value_in_config(self, mocked_parse_args, mocked_request, mocked_sleep):
+        json = {"key": "value"}
+        # mock response
+        mocked_request.return_value = get_response(200, json)
+
+        mock_config = {"request_timeout": "100"}
+        # mock parse args
+        mocked_parse_args.return_value = get_args(mock_config)
+
+        # get the timeout value for assertion
+        timeout = tap_github.get_request_timeout()
+        # function call
+        tap_github.authed_get("test_source", "")
+
+        # verify that we got expected timeout value
+        self.assertEquals(100.0, timeout)
+        # verify that the request was called with expected timeout value
+        mocked_request.assert_called_with(method='get', url='', timeout=100.0)
+
+    def test_timeout_empty_value_in_config(self, mocked_parse_args, mocked_request, mocked_sleep):
+        json = {"key": "value"}
+        # mock response
+        mocked_request.return_value = get_response(200, json)
+
+        mock_config = {"request_timeout": ""}
+        # mock parse args
+        mocked_parse_args.return_value = get_args(mock_config)
+
+        # get the timeout value for assertion
+        timeout = tap_github.get_request_timeout()
+        # function call
+        tap_github.authed_get("test_source", "")
+
+        # verify that we got expected timeout value
+        self.assertEquals(300.0, timeout)
+        # verify that the request was called with expected timeout value
+        mocked_request.assert_called_with(method='get', url='', timeout=300.0)
+
+    def test_timeout_0_value_in_config(self, mocked_parse_args, mocked_request, mocked_sleep):
+        json = {"key": "value"}
+        # mock response
+        mocked_request.return_value = get_response(200, json)
+
+        mock_config = {"request_timeout": 0.0}
+        # mock parse args
+        mocked_parse_args.return_value = get_args(mock_config)
+
+        # get the timeout value for assertion
+        timeout = tap_github.get_request_timeout()
+        # function call
+        tap_github.authed_get("test_source", "")
+
+        # verify that we got expected timeout value
+        self.assertEquals(300.0, timeout)
+        # verify that the request was called with expected timeout value
+        mocked_request.assert_called_with(method='get', url='', timeout=300.0)
+
+    def test_timeout_string_0_value_in_config(self, mocked_parse_args, mocked_request, mocked_sleep):
+        json = {"key": "value"}
+        # mock response
+        mocked_request.return_value = get_response(200, json)
+
+        mock_config = {"request_timeout": "0.0"}
+        # mock parse args
+        mocked_parse_args.return_value = get_args(mock_config)
+
+        # get the timeout value for assertion
+        timeout = tap_github.get_request_timeout()
+        # function call
+        tap_github.authed_get("test_source", "")
+
+        # verify that we got expected timeout value
+        self.assertEquals(300.0, timeout)
+        # verify that the request was called with expected timeout value
+        mocked_request.assert_called_with(method='get', url='', timeout=300.0)
+
+@mock.patch("time.sleep")
+@mock.patch("requests.Session.request")
+@mock.patch("singer.utils.parse_args")
+class TestTimeoutAndConnnectionErrorBackoff(unittest.TestCase):
+    """
+        Test case to verify that we backoff for 5 times for Connection and Timeout error
+    """
+
+    def test_timeout_backoff(self, mocked_parse_args, mocked_request, mocked_sleep):
+        # mock request and raise 'Timeout' error
+        mocked_request.side_effect = requests.Timeout
+
+        mock_config = {}
+        # mock parse args
+        mocked_parse_args.return_value = get_args(mock_config)
+
+        try:
+            # function call
+            tap_github.authed_get("test_source", "")
+        except requests.Timeout:
+            pass
+
+        # verify that we backoff 5 times
+        self.assertEquals(5, mocked_request.call_count)
+
+    def test_connection_error_backoff(self, mocked_parse_args, mocked_request, mocked_sleep):
+        # mock request and raise 'Connection' error
+        mocked_request.side_effect = requests.ConnectionError
+
+        mock_config = {}
+        # mock parse args
+        mocked_parse_args.return_value = get_args(mock_config)
+
+        try:
+            # function call
+            tap_github.authed_get("test_source", "")
+        except requests.ConnectionError:
+            pass
+
+        # verify that we backoff 5 times
+        self.assertEquals(5, mocked_request.call_count)


### PR DESCRIPTION
# Description of change
TDL-16349: Add request timeout
- Use default timeout of 300 seconds if the user does not enter the preferred timeout value

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
