### PR TITLE
TDL-16550: Add support of object in "parent" field for teams - (Copy of PR #107)

### DIFF
--- a/tap_github/schemas/teams.json
+++ b/tap_github/schemas/teams.json
@@ -79,6 +79,7 @@
     "parent": {
       "type": [
         "null",
+        "object",
         "string"
       ]
     }


### PR DESCRIPTION
# Description of change
TDL-16550: Add support of object in "parent" field for teams
- Added "object" datatype for the "parent" field in the "teams" stream

NOTE: Created parent-child teams from another account and verified the code change using Import API from the stitch UI

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
