### PR TITLE
Fix team_members stream PK

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -39,7 +39,7 @@ KEY_PROPERTIES = {
     'project_cards': ['id'],
     'repos': ['id'],
     'teams': ['id'],
-    'team_members': ['id'],
+    'team_members': ['id', 'team_slug'],
     'team_memberships': ['url']
 }
 
@@ -442,6 +442,7 @@ def get_all_team_members(team_slug, schemas, repo_path, state, mdata):
             team_members = response.json()
             for r in team_members:
                 r['_sdc_repository'] = repo_path
+                r['team_slug'] = team_slug
 
                 # transform and write release record
                 with singer.Transformer() as transformer:

--- a/tap_github/schemas/team_members.json
+++ b/tap_github/schemas/team_members.json
@@ -117,6 +117,12 @@
           "null",
           "string"
         ]
+      },
+      "team_slug": {
+        "type": [
+          "null",
+          "string"
+        ]
       }
     }
   }

--- a/tests/base.py
+++ b/tests/base.py
@@ -176,7 +176,7 @@ class TestGithubBase(unittest.TestCase):
                 self.OBEYS_START_DATE: False
             },
             "team_members": {
-                self.PRIMARY_KEYS: {"id"},
+                self.PRIMARY_KEYS: {"id", "team_slug"},
                 self.REPLICATION_METHOD: self.FULL,
                 self.OBEYS_START_DATE: False
             },

--- a/tests/test_github_automatic_fields.py
+++ b/tests/test_github_automatic_fields.py
@@ -64,10 +64,8 @@ class TestGithubAutomaticFields(TestGithubBase):
                 for actual_keys in record_messages_keys:
                     self.assertSetEqual(expected_keys, actual_keys)
 
-                # BUG-TDL-17507 An org can have multiple teams with overlapping membership
-                if stream != 'team_members':
-                    # Verify that all replicated records have unique primary key values.
-                    self.assertEqual(
-                        len(primary_keys_list),
-                        len(unique_primary_keys_list),
-                        msg="Replicated record does not have unique primary key values.")
+                # Verify that all replicated records have unique primary key values.
+                self.assertEqual(
+                    len(primary_keys_list),
+                    len(unique_primary_keys_list),
+                    msg="Replicated record does not have unique primary key values.")


### PR DESCRIPTION
# Description of change
Fixes bug for `team_members` stream as per [TDL-17507](https://jira.talendforge.org/browse/TDL-17507)

# Manual QA steps
 - ran tap locally w/ `singer-check-tap` and `target-stitch --dry-run`
 - circle tests passing
 
# Risks
 - primary keys change for `team_members` stream
 
# Rollback steps
 - revert this branch
