### PR TITLE
Add tags schema with full replication

### DIFF
--- a/tap_github/schemas/tags.json
+++ b/tap_github/schemas/tags.json
@@ -1,0 +1,33 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": ["null", "string"]
+    },
+    "zipball_url": {
+      "type": ["null", "string"]
+    },
+    "tarball_url": {
+      "type": ["null", "string"]
+    },
+    "commit": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "sha": {
+          "type": ["null", "string"]
+        },
+        "url": {
+          "type": ["null", "string"]
+        }
+      }
+    },
+    "node_id": {
+      "type": ["null", "string"]
+    },
+    "_sdc_repository": {
+      "type": ["string"]
+    }
+  }
+}


### PR DESCRIPTION
Add support for tags. Same code of #64, but adapted to new version. Because we need this functionality and the mantainer probably is not available.
