### PR TITLE
Add user login attribute to stagazers schema

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1043,10 +1043,12 @@ def get_all_stargazers(schema, repo_path, state, mdata, _start_date):
             extraction_time = singer.utils.now()
             for stargazer in stargazers:
                 user_id = stargazer['user']['id']
+                login = stargazer['user']['login']
                 stargazer['_sdc_repository'] = repo_path
                 with singer.Transformer() as transformer:
                     rec = transformer.transform(stargazer, schema, metadata=metadata.to_map(mdata))
                 rec['user_id'] = user_id
+                rec['login'] = login
                 singer.write_record('stargazers', rec, time_extracted=extraction_time)
                 counter.increment()
 

--- a/tap_github/schemas/stargazers.json
+++ b/tap_github/schemas/stargazers.json
@@ -20,6 +20,9 @@
     },
     "user_id": {
       "type": ["null", "integer"]
+    },
+    "login": {
+      "type": ["null", "string"]
     }
   }
 }


### PR DESCRIPTION
# Description of change
This adds the `login` attribute of the [stargazers response object](https://docs.github.com/en/rest/activity/starring#list-stargazers) to the Stargazers schema.

# Manual QA steps
 - I ran the tap locally to ensure this was working as expected:
 ```
$ tap-github --config config.json --properties properties.json
{"type": "STATE", "value": {}}
INFO Starting sync of repository: wandb/local
{"type": "SCHEMA", "stream": "stargazers", "schema": {"selected": true, "type": ["null", "object"], "additionalProperties": false, "properties": {"_sdc_repository": {"type": ["string"]}, "user": {"type": ["null", "object"], "additionalProperties": false, "properties": {"id": {"type": ["null", "integer"]}}}, "starred_at": {"type": ["null", "string"], "format": "date-time"}, "user_id": {"type": ["null", "integer"]}, "login": {"type": ["null", "string"]}}}, "key_properties": ["user_id"]}
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.396655797958374, "tags": {"endpoint": "stargazers", "http_status_code": 200, "status": "succeeded"}}
{"type": "RECORD", "stream": "stargazers", "record": {"starred_at": "2020-10-22T17:18:25.000000Z", "user": {"id": 6808929}, "_sdc_repository": "wandb/local", "user_id": 6808929, "login": "szelenka"}, "time_extracted": "2022-06-29T21:57:16.074995Z"}
{"type": "RECORD", "stream": "stargazers", "record": {"starred_at": "2020-10-22T17:22:57.000000Z", "user": {"id": 7882515}, "_sdc_repository": "wandb/local", "user_id": 7882515, "login": "dmeyer3691"}, "time_extracted": "2022-06-29T21:57:16.074995Z"}
```
 
# Risks
 - Since this is only adding an attribute and not changing the granularity of the report this should be low-risk.
 
# Rollback steps
 - revert this branch
