### PR TITLE
TDL-5961 Support of custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,18 @@ This tap:
 3. Create the config file
 
     Create a JSON file containing the start date, access token you just created
-    and the path to one or multiple repositories that you want to extract data from. Each repo path should be space delimited. The repo path is relative to
-    `https://github.com/`. For example the path for this repository is
+    and the path to one or multiple repositories that you want to extract data from. Each repo path should be space delimited. The repo path is relative to `"base_url"`
+    (Default: `https://github.com/`). For example the path for this repository is
     `singer-io/tap-github`. You can also add request timeout to set the timeout for requests which is an optional parameter with default value of 300 seconds.
 
     ```json
-    {"access_token": "your-access-token",
-     "repository": "singer-io/tap-github singer-io/getting-started",
-     "start_date": "2021-01-01T00:00:00Z",
-     "request_timeout": 300}
+    {
+      "access_token": "your-access-token",
+      "repository": "singer-io/tap-github singer-io/getting-started",
+      "start_date": "2021-01-01T00:00:00Z",
+      "request_timeout": 300,
+      "base_url": "https://api.github.com"
+    }
     ```
 4. Run the tap in discovery mode to get properties.json file
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -2,5 +2,6 @@
     "access_token": "abcdefghijklmnopqrstuvwxyz1234567890ABCD",
     "repository": "singer-io/target-stitch",
     "start_date": "2021-01-01T00:00:00Z",
-    "request_timeout": 300
+    "request_timeout": 300,
+    "base_url": "https://api.github.com"
 }

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -138,7 +138,7 @@ class GithubClient:
     def __init__(self, config):
         self.config = config
         self.session = requests.Session()
-        self.base_url = config.get('api_endpoint', DEFAULT_DOMAIN)
+        self.base_url = config.get('base_url', DEFAULT_DOMAIN)
         self.max_sleep_seconds = self.config.get('max_sleep_seconds', DEFAULT_SLEEP_SECONDS)
 
     # Return the 'timeout'

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -158,7 +158,6 @@ class GithubClient:
         self.set_auth_in_session()
         self.not_accessible_repos = set()
 
-    # Return the 'timeout'
     def get_request_timeout(self):
         """
         Get the request timeout from the config, if not present use the default 300 seconds.
@@ -168,7 +167,6 @@ class GithubClient:
 
         # Only return the timeout value if it is passed in the config and the value is not 0, "0" or ""
         if config_request_timeout and float(config_request_timeout):
-            # Return the timeout from config
             return float(config_request_timeout)
 
         # Return default timeout

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -153,7 +153,7 @@ class GithubClient:
     def __init__(self, config):
         self.config = config
         self.session = requests.Session()
-        self.base_url = config.get('base_url', DEFAULT_DOMAIN)
+        self.base_url = config['base_url'] if config.get('base_url') else DEFAULT_DOMAIN
         self.max_sleep_seconds = self.config.get('max_sleep_seconds', DEFAULT_SLEEP_SECONDS)
         self.set_auth_in_session()
         self.not_accessible_repos = set()

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -7,6 +7,7 @@ from singer import metrics
 
 LOGGER = singer.get_logger()
 DEFAULT_SLEEP_SECONDS = 600
+DEFAULT_DOMAIN = "https://api.github.com"
 
 # Set default timeout of 300 seconds
 REQUEST_TIMEOUT = 300
@@ -137,7 +138,7 @@ class GithubClient:
     def __init__(self, config):
         self.config = config
         self.session = requests.Session()
-        self.base_url = "https://api.github.com"
+        self.base_url = config.get('api_endpoint', DEFAULT_DOMAIN)
         self.max_sleep_seconds = self.config.get('max_sleep_seconds', DEFAULT_SLEEP_SECONDS)
 
     # Return the 'timeout'
@@ -261,7 +262,7 @@ class GithubClient:
                     repo_full_name = repo.get('full_name')
 
                     self.verify_repo_access(
-                        'https://api.github.com/repos/{}/commits'.format(repo_full_name),
+                        '{}/repos/{}/commits'.format(self.base_url, repo_full_name),
                         repo
                     )
 

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -67,12 +67,11 @@ class Stream:
     is_repository = False
     headers = None
     parent = None
-    url = "https://api.github.com"
 
     def add_fields_at_1st_level(self, rec, parent_record):
         pass
 
-    def build_url(self, repo_path, bookmark):
+    def build_url(self, base_url, repo_path, bookmark):
         """
         Build the full url with parameters and attributes.
         """
@@ -85,11 +84,11 @@ class Stream:
         if self.is_organization:
             org = repo_path.split('/')[0]
             full_url = '{}/{}'.format(
-                self.url,
+                base_url,
                 self.path).format(org)
         else:
             full_url = '{}/repos/{}/{}{}'.format(
-                self.url,
+                base_url,
                 repo_path,
                 self.path,
                 query_string)
@@ -207,8 +206,7 @@ class FullTableStream(Stream):
         """
 
         # build full url
-        self.url = client.base_url
-        full_url = self.build_url(repo_path, None)
+        full_url = self.build_url(client.base_url, repo_path, None)
 
         headers = {}
         if self.headers:
@@ -282,8 +280,7 @@ class IncrementalStream(Stream):
         max_bookmark_value = min_bookmark_value
 
         # build full url
-        self.url = client.base_url
-        full_url = self.build_url(repo_path, min_bookmark_value)
+        full_url = self.build_url(client.base_url, repo_path, min_bookmark_value)
 
         headers = {}
         if self.headers:
@@ -372,8 +369,7 @@ class IncrementalOrderedStream(Stream):
         bookmark_time = singer.utils.strptime_to_utc(min_bookmark_value)
 
         # Build full url
-        self.url = client.domain
-        full_url = self.build_url(repo_path, bookmark_value)
+        full_url = self.build_url(client.base_url, repo_path, bookmark_value)
         synced_all_records = False
         stream_catalog = get_schema(catalog, self.tap_stream_id)
 

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -8,6 +8,14 @@ class TestGithubSync(TestGithubBase):
     def name():
         return "tap_tester_github_sync_test"
 
+    def get_properties(self):
+
+        return {
+            'start_date' : '2021-10-01T00:00:00Z',
+            'base_url': 'https://api.github.com',
+            'repository': 'singer-io/test-repo'
+        }
+
     def test_run(self):
         """
         Testing that sync creates the appropriate catalog with valid metadata.

--- a/tests/unittests/test_custom_domain.py
+++ b/tests/unittests/test_custom_domain.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest import mock
+from tap_github.client import GithubClient, DEFAULT_DOMAIN
+
+@mock.patch('tap_github.GithubClient.verify_access_for_repo', return_value = None)
+class TestCustomDomain(unittest.TestCase):
+    """
+    Test custom domain is supported in client
+    """
+
+    def test_config_without_domain(self, mock_verify_access):
+        """
+        Test if the domain is not given in the config
+        """
+        mock_config = {'repository': 'singer-io/test-repo', "access_token": ""}
+        test_client = GithubClient(mock_config)
+
+        # Verify domain in client is default
+        self.assertEqual(test_client.base_url, DEFAULT_DOMAIN)
+    
+    def test_config_with_domain(self, mock_verify_access):
+        """
+        Test if the domain is given in the config
+        """
+        mock_config = {'repository': 'singer-io/test-repo', "api_endpoint": "http://CUSTOM-git.com", "access_token": ""}
+        test_client = GithubClient(mock_config)
+
+        # Verify domain in client is from config
+        self.assertEqual(test_client.base_url, mock_config["api_endpoint"])

--- a/tests/unittests/test_custom_domain.py
+++ b/tests/unittests/test_custom_domain.py
@@ -22,8 +22,8 @@ class TestCustomDomain(unittest.TestCase):
         """
         Test if the domain is given in the config
         """
-        mock_config = {'repository': 'singer-io/test-repo', "api_endpoint": "http://CUSTOM-git.com", "access_token": ""}
+        mock_config = {'repository': 'singer-io/test-repo', "base_url": "http://CUSTOM-git.com", "access_token": ""}
         test_client = GithubClient(mock_config)
 
         # Verify domain in client is from config
-        self.assertEqual(test_client.base_url, mock_config["api_endpoint"])
+        self.assertEqual(test_client.base_url, mock_config["base_url"])

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -16,7 +16,7 @@ class TestGetSchema(unittest.TestCase):
             {"tap_stream_id": "events"},
         ]
         expected_schema = {"tap_stream_id": "comments"}
-        
+
         # Verify returned schema is same as exected schema 
         self.assertEqual(get_schema(catalog, "comments"), expected_schema)
 
@@ -27,7 +27,7 @@ class TestGetBookmark(unittest.TestCase):
     """
 
     test_stream = Comments()
-    
+
     def test_with_out_repo_path(self):
         """
         Test if state does not contains repo path
@@ -39,7 +39,7 @@ class TestGetBookmark(unittest.TestCase):
         }
         returned_bookmark = get_bookmark(state, "org/test-repo", "projects", "since", "2021-01-01T00:00:00Z")
         self.assertEqual(returned_bookmark, "2021-01-01T00:00:00Z")
-        
+
     def test_with_repo_path(self):
         """
         Test if state does contains repo path
@@ -59,14 +59,15 @@ class TestBuildUrl(unittest.TestCase):
     """
     Test `build_url` method of stream class
     """
-    
+    base_url = "https://api.github.com"
+
     def test_stream_with_filter_params(self):
         """
         Test for stream with filter param
         """
         test_streams = Comments()
         expected_url = "https://api.github.com/repos/org/test-repo/issues/comments?sort=updated&direction=desc?since=2022-01-01T00:00:00Z"
-        full_url = test_streams.build_url("org/test-repo", "2022-01-01T00:00:00Z")
+        full_url = test_streams.build_url(self.base_url, "org/test-repo", "2022-01-01T00:00:00Z")
 
         # verify returned url is expected
         self.assertEqual(expected_url, full_url)
@@ -77,7 +78,7 @@ class TestBuildUrl(unittest.TestCase):
         """
         test_streams = Teams()
         expected_url = "https://api.github.com/orgs/org/teams"
-        full_url = test_streams.build_url("org/test-repo", "2022-01-01T00:00:00Z")
+        full_url = test_streams.build_url(self.base_url, "org/test-repo", "2022-01-01T00:00:00Z")
 
         # verify returned url is expected
         self.assertEqual(expected_url, full_url)
@@ -85,7 +86,7 @@ class TestBuildUrl(unittest.TestCase):
 
 class GetMinBookmark(unittest.TestCase):
     """
-    Test `get_min_bookmark` method of stream class
+    Test `get_min_bookmark` method of the stream class
     """
 
     state = {
@@ -112,7 +113,7 @@ class GetMinBookmark(unittest.TestCase):
 
         # Verify returned bookmark is expected
         self.assertEqual(bookmark, "2022-02-01T00:00:00Z")
-    
+
     def test_children_with_only_parent_selected(self):
         """
         Test for stream with multiple children and only parent is selected
@@ -123,7 +124,7 @@ class GetMinBookmark(unittest.TestCase):
 
         # Verify returned bookmark is expected
         self.assertEqual(bookmark, "2022-04-01T00:00:00Z")
-    
+
     def test_for_mid_child_in_stream(self):
         """
         Test for stream with multiple children and mid_child is selected
@@ -134,7 +135,7 @@ class GetMinBookmark(unittest.TestCase):
 
         # Verify returned bookmark is expected
         self.assertEqual(bookmark, "2022-03-01T00:00:00Z")
-    
+
     def test_nested_child_bookmark(self):
         """
         Test for stream with multiple children and nested child is selected
@@ -206,6 +207,7 @@ class TestGetChildUrl(unittest.TestCase):
     """
     Test `get_child_full_url` method of stream class
     """
+    domain = 'https://api.github.com'
 
     def test_child_stream(self):
         """
@@ -213,7 +215,7 @@ class TestGetChildUrl(unittest.TestCase):
         """
         child_stream = ProjectColumns()
         expected_url = "https://api.github.com/projects/1309875/columns"
-        full_url = get_child_full_url(child_stream, "org1/test-repo",
+        full_url = get_child_full_url(self.domain, child_stream, "org1/test-repo",
                                                        None, (1309875,))
         self.assertEqual(expected_url, full_url)
 
@@ -223,7 +225,7 @@ class TestGetChildUrl(unittest.TestCase):
         """
         child_stream = Reviews()
         expected_url = "https://api.github.com/repos/org1/test-repo/pulls/11/reviews"
-        full_url = get_child_full_url(child_stream, "org1/test-repo",
+        full_url = get_child_full_url(self.domain, child_stream, "org1/test-repo",
                                                        (11,), None)
         self.assertEqual(expected_url, full_url)
 
@@ -233,6 +235,6 @@ class TestGetChildUrl(unittest.TestCase):
         """
         child_stream = TeamMemberships()
         expected_url = "https://api.github.com/orgs/org1/teams/dev-team/memberships/demo-user-1"
-        full_url = get_child_full_url(child_stream, "org1/test-repo",
+        full_url = get_child_full_url(self.domain, child_stream, "org1/test-repo",
                                                        ("dev-team",), ("demo-user-1",))
         self.assertEqual(expected_url, full_url)

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -69,7 +69,7 @@ class TestBuildUrl(unittest.TestCase):
         Test the `build_url` method for filter param or organization name only.
         """
         test_streams = stream_class()
-        full_url = test_streams.build_url("org/test-repo", "2022-01-01T00:00:00Z")
+        full_url = test_streams.build_url("https://api.github.com", "org/test-repo", "2022-01-01T00:00:00Z")
 
         # verify returned url is expected
         self.assertEqual(expected_url, full_url)
@@ -185,5 +185,5 @@ class TestGetChildUrl(unittest.TestCase):
         Test for a stream with one child
         """
         child_stream = stream_class()
-        full_url = get_child_full_url(child_stream, "org1/test-repo", parent_id, grand_parent_id)
+        full_url = get_child_full_url(self.domain, child_stream, "org1/test-repo", parent_id, grand_parent_id)
         self.assertEqual(expected_url, full_url)

--- a/tests/unittests/test_verify_access.py
+++ b/tests/unittests/test_verify_access.py
@@ -73,18 +73,3 @@ class TestCredentials(unittest.TestCase):
 
         # Verify error with proper message
         self.assertEqual(str(e.exception), "HTTP-error-code: 401, Error: {}".format(json))
-
-
-@mock.patch("tap_github.client.LOGGER.warning")
-@mock.patch("tap_github.client.GithubClient.verify_repo_access", return_value = None)
-class TestRepoCallCount(unittest.TestCase):
-    def test_repo_call_count(self, mocked_repo, mocked_logger_info):
-        """
-            Here 3 repos are given,
-            so tap will check creds for all 3 repos
-        """
-
-        config = {"access_token": "access_token", "repository": "org1/repo1 org1/repo2 org2/repo1"}
-        GithubClient(config)
-
-        self.assertEqual(mocked_repo.call_count, 3)


### PR DESCRIPTION
# Description of change
- Added support of custom domain.
- Added unit test case for the changes.

**Note**: Build is failing because config parameter `base_url` is missing.
# Manual QA steps
 - Verify that if a custom domain is provided in the config then that domain is being used by tap to call the REST API.
 - Verify that if a custom domain is not provided in the config then that default domain is being used by tap to call the REST API.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
