### PR TITLE
Tdl 20302 add query param for pull requests

### DIFF
--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -513,7 +513,7 @@ class PullRequests(IncrementalOrderedStream):
     replication_method = "INCREMENTAL"
     replication_keys = "updated_at"
     key_properties = ["id"]
-    path = "pulls?state=all"
+    path = "pulls?state=all&sort=updated&direction=desc"
     children = ['reviews', 'review_comments', 'pr_commits']
     pk_child_fields = ["number"]
 

--- a/tests/test_github_interrupted_sync.py
+++ b/tests/test_github_interrupted_sync.py
@@ -145,7 +145,7 @@ class TestGithubInterruptedSync(TestGithubBase):
                                         rec_time = self.dt_to_ts(record[expected_replication_key], self.RECORD_REPLICATION_KEY_FORMAT)
                                         self.assertGreaterEqual(rec_time, start_date)
 
-                                        if (rec_time > interrupted_bookmark):
+                                        if (rec_time >= interrupted_bookmark):
                                             full_records_after_interrupted_bookmark += 1
                                             
                                     self.assertEqual(full_records_after_interrupted_bookmark, len(interrupted_records), \

--- a/tests/test_github_interrupted_sync.py
+++ b/tests/test_github_interrupted_sync.py
@@ -133,7 +133,7 @@ class TestGithubInterruptedSync(TestGithubBase):
 
                                     for record in interrupted_records:
                                         rec_time = self.dt_to_ts(record[expected_replication_key], self.RECORD_REPLICATION_KEY_FORMAT)
-                                        self.assertGreater(rec_time, interrupted_bookmark)
+                                        self.assertGreaterEqual(rec_time, interrupted_bookmark)
 
                                         # Verify all interrupted recs are in full recs
                                         self.assertIn(record, full_records,  msg='incremental table record in interrupted sync not found in full sync')
@@ -143,7 +143,7 @@ class TestGithubInterruptedSync(TestGithubBase):
 
                                     for record in full_records:
                                         rec_time = self.dt_to_ts(record[expected_replication_key], self.RECORD_REPLICATION_KEY_FORMAT)
-                                        self.assertGreater(rec_time, start_date)
+                                        self.assertGreaterEqual(rec_time, start_date)
 
                                         if (rec_time > interrupted_bookmark):
                                             full_records_after_interrupted_bookmark += 1
@@ -152,7 +152,7 @@ class TestGithubInterruptedSync(TestGithubBase):
                                                         msg="Expected {} records in each sync".format(full_records_after_interrupted_bookmark))
                                 else:
                                     # Verify we collected records that have the same replication value as a bookmark for streams that are already synced
-                                    self.assertGreater(interrupted_record_count, 0)
+                                    self.assertGreaterEqual(interrupted_record_count, 0)
                             else:
                                 # Verify resuming sync replicates all records that were found in the full sync (uninterrupted)
                                 for record in interrupted_records:

--- a/tests/unittests/test_sync_endpoint.py
+++ b/tests/unittests/test_sync_endpoint.py
@@ -240,7 +240,7 @@ class TestIncrementalOrderedStream(unittest.TestCase):
         test_stream.sync_endpoint(test_client, {}, self.catalog, "tap-github", "", ["pull_requests"], ["pull_requests"])
 
         # Verify that the authed_get_all_pages() is called with the expected url
-        mock_authed_get_all_pages.assert_called_with(mock.ANY, "https://api.github.com/repos/tap-github/pulls?state=all", stream='pull_requests')
+        mock_authed_get_all_pages.assert_called_with(mock.ANY, "https://api.github.com/repos/tap-github/pulls?state=all&sort=updated&direction=desc", stream='pull_requests')
 
 
     @mock.patch("tap_github.streams.Stream.get_child_records")
@@ -257,7 +257,7 @@ class TestIncrementalOrderedStream(unittest.TestCase):
         test_stream.sync_endpoint(test_client, {}, self.catalog, "tap-github", "", ["pull_requests", "review_comments"], ["pull_requests","review_comments"])
 
         # Verify that the authed_get_all_pages() is called with the expected url
-        mock_authed_get_all_pages.assert_called_with(mock.ANY, "https://api.github.com/repos/tap-github/pulls?state=all", stream='pull_requests')
+        mock_authed_get_all_pages.assert_called_with(mock.ANY, "https://api.github.com/repos/tap-github/pulls?state=all&sort=updated&direction=desc", stream='pull_requests')
         
         # Verify that the get_child_records() is called as the PullRequests stream has a child stream
         self.assertTrue(mock_get_child_records.called)
@@ -281,7 +281,7 @@ class TestIncrementalOrderedStream(unittest.TestCase):
         self.assertEqual(mock_authed_get_all_pages.call_count, 2)
         
         print(mock_authed_get_all_pages.mock_calls)
-        exp_call_1 = mock.call(mock.ANY, "https://api.github.com/repos/tap-github/pulls?state=all", stream='pull_requests')
+        exp_call_1 = mock.call(mock.ANY, "https://api.github.com/repos/tap-github/pulls?state=all&sort=updated&direction=desc", stream='pull_requests')
         exp_call_2 = mock.call(mock.ANY, "https://api.github.com/repos/tap-github/pulls/1/comments?sort=updated_at&direction=desc", stream='review_comments')
 
         # Verify that the API calls are done as expected with the correct url


### PR DESCRIPTION
# Description of change
- Added query param for the `pull_requests` stream.
- An updated unit test case for the `pull_requests` stream.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
