### PR TITLE
TDL 20339 handle empty bookmark if all repos unselected for next sync.

### DIFF
--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -100,20 +100,23 @@ def translate_state(state, catalog, repositories):
     # Collect stream names from the catalog
     stream_names = [stream['tap_stream_id'] for stream in catalog['streams']]
 
-    all_repos_unselected=True
+    all_repos_deselected=True
     for key in previous_state_keys:
         # Loop through each key of `bookmarks` available in the previous state.
         # Check if it is the stream name or not. Older connections `bookmarks` contain stream names.
-        # Mark `all_repos_unselected` as `False` if at least one stream name is found in the previous state's keys because we want 
+        # Mark `all_repos_deselected` as `False` if at least one stream name is found in the previous state's keys because we want 
         # to migrate each stream's bookmark into the repo name.
         # Example: {`bookmarks`: {`stream_a`: `bookmark_a`}} to {`bookmarks`: {`repo_a`: {`stream_a`: `bookmark_a`}}}
         # Check if the key is available in the list of currently selected repo's list or not. Newer format `bookmarks` contain repo names.
-        # Mark `all_repos_unselected` as `False` if at least one repo name matches the previous state's keys.
+        # Mark `all_repos_deselected` as `False` if at least one repo name matches the previous state's keys.
+        # At last, if `all_repos_deselected` remain True, then we will return the state itself.
+        # If the state contains bookmark for `repo_a` and `repo_b` and the user deselects these both repos and adds another repo
+        # then in that case this function was returning an empty state. Now this change will return the existing state instead of the empty state.
         if key in stream_names or key in repositories:
-            all_repos_unselected=False
+            all_repos_deselected=False
 
-    # Return the existing state if all repos from the previous state are unselected(not found) in the current sync.
-    if all_repos_unselected:
+    # Return the existing state if all repos from the previous state are deselected(not found) in the current sync.
+    if all_repos_deselected:
         return state
 
     for stream in catalog['streams']:
@@ -134,7 +137,7 @@ def get_stream_to_sync(catalog):
     selected_streams = get_selected_streams(catalog)
     for stream_name, stream_obj in STREAMS.items():
         if stream_name in selected_streams or is_any_child_selected(stream_obj, selected_streams):
-            # Append the selected stream or unselected parent stream into the list, if its child or nested child is selected.
+            # Append the selected stream or deselected parent stream into the list, if its child or nested child is selected.
             streams_to_sync.append(stream_name)
     return streams_to_sync
 

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -109,18 +109,20 @@ def translate_state(state, catalog, repositories):
 
         # Case 1:
         # Check if it is the stream name or not. Older connections `bookmarks` contain stream names.
-        # Mark `all_repos_deselected` as `False` if at least one stream name is found in the previous state's keys because we want
+        # Mark `deselected_repos` as `False` if at least one stream name is found in the previous state's keys because we want
         # to migrate each stream's bookmark into the repo name.
         # Example: {`bookmarks`: {`stream_a`: `bookmark_a`}} to {`bookmarks`: {`repo_a`: {`stream_a`: `bookmark_a`}}}
 
         # Case 2:
         # Check if the key is available in the list of currently selected repo's list or not. Newer format `bookmarks` contain repo names.
-        # Mark `all_repos_deselected` as `False` if at least one repo name matches the previous state's keys.
+        # Mark `deselected_repos` as `False` if at least one repo name matches the previous state's keys.
 
-        # At last, if `all_repos_deselected` remain True, then we will return the state itself.
+        # At last, if `deselected_repos` remain True, then we will return the state itself. Because If the state contains a bookmark
+        # for `repo_a` and `repo_b` and the user deselects these both repos and adds another repo
+        # then in that case this function was returning an empty state. Now this change will return the existing state instead of the empty state.
 
         if key in stream_names or key in repositories:
-            all_repos_deselected=False
+            deselected_repos=False
 
     # Return the existing state if all repos from the previous state are deselected(not found) in the current sync.
     if deselected_repos:

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -95,6 +95,16 @@ def translate_state(state, catalog, repositories):
     nested_dict = lambda: collections.defaultdict(nested_dict)
     new_state = nested_dict()
 
+    # Collect keys(repo_name for update state or stream_name for older state) from state available in the `bookmarks`
+    previous_state_keys = state.get('bookmarks', {}).keys()
+    # Collect stream names from the catalog
+    stream_names = [stream['tap_stream_id'] for stream in catalog['streams']]
+
+    for key in previous_state_keys:
+        # Return the existing state if all repos from the previous state are unselected in the current sync.
+        if key not in stream_names and key not in repositories:
+            return state
+
     for stream in catalog['streams']:
         stream_name = stream['tap_stream_id']
         for repo in repositories:

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -100,23 +100,30 @@ def translate_state(state, catalog, repositories):
     # Collect stream names from the catalog
     stream_names = [stream['tap_stream_id'] for stream in catalog['streams']]
 
-    all_repos_deselected=True
+    deselected_repos=True
+    # If the state contains bookmark for `repo_a` and `repo_b` and the user deselects these both repos and adds another repo
+    # then in that case this function was returning an empty state. Now this change will return the existing state instead of the empty state.
+   
     for key in previous_state_keys:
         # Loop through each key of `bookmarks` available in the previous state.
+
+        # Case 1:
         # Check if it is the stream name or not. Older connections `bookmarks` contain stream names.
-        # Mark `all_repos_deselected` as `False` if at least one stream name is found in the previous state's keys because we want 
+        # Mark `all_repos_deselected` as `False` if at least one stream name is found in the previous state's keys because we want
         # to migrate each stream's bookmark into the repo name.
         # Example: {`bookmarks`: {`stream_a`: `bookmark_a`}} to {`bookmarks`: {`repo_a`: {`stream_a`: `bookmark_a`}}}
+
+        # Case 2:
         # Check if the key is available in the list of currently selected repo's list or not. Newer format `bookmarks` contain repo names.
         # Mark `all_repos_deselected` as `False` if at least one repo name matches the previous state's keys.
+
         # At last, if `all_repos_deselected` remain True, then we will return the state itself.
-        # If the state contains bookmark for `repo_a` and `repo_b` and the user deselects these both repos and adds another repo
-        # then in that case this function was returning an empty state. Now this change will return the existing state instead of the empty state.
+
         if key in stream_names or key in repositories:
             all_repos_deselected=False
 
     # Return the existing state if all repos from the previous state are deselected(not found) in the current sync.
-    if all_repos_deselected:
+    if deselected_repos:
         return state
 
     for stream in catalog['streams']:

--- a/tests/unittests/test_get_streams_and_state_translate.py
+++ b/tests/unittests/test_get_streams_and_state_translate.py
@@ -71,10 +71,8 @@ class TestTranslateState(unittest.TestCase):
 
         self.assertEqual({}, dict(final_state))
 
-    def test_state_with_no_previous_repo_name(self):
-        """
-        Verify that `translate_state` return the existing state if all existing repos are unselected in the current sync.
-        """
+    def test_state_with_no_previous_repo_name_newer_format_bookmark(self):
+        """Verify that `translate_state` return the existing state if all existing repo unselected in the current sync."""
         state = {
             "bookmarks": {
                 "org/test-repo" : {
@@ -85,6 +83,26 @@ class TestTranslateState(unittest.TestCase):
         }
         final_state = translate_state(state, self.catalog, ["org/test-repo3", "org/test-repo4"])
         self.assertEqual(state, dict(final_state))
+
+    def test_state_with_no_previous_repo_name_old_format_bookmark(self):
+        """Verify that `translate_state` migrate each stream's bookmark into the repo name"""
+        state = {
+            "bookmarks": {
+                "comments": {"since": "2019-01-01T00:00:00Z"}
+            }
+        }
+        expected_state = {
+            "bookmarks": {
+                "org/test-repo3" : {
+                        "comments": {"since": "2019-01-01T00:00:00Z"}
+                    },
+                "org/test-repo4" : {
+                        "comments": {"since": "2019-01-01T00:00:00Z"}
+                    }
+            }
+        }
+        final_state = translate_state(state, self.catalog, ["org/test-repo3", "org/test-repo4"])
+        self.assertEqual(expected_state, dict(final_state))
 
 class TestGetStreamsToSync(unittest.TestCase):
     """

--- a/tests/unittests/test_get_streams_and_state_translate.py
+++ b/tests/unittests/test_get_streams_and_state_translate.py
@@ -30,8 +30,8 @@ class TestTranslateState(unittest.TestCase):
         ]
     }
 
-    def test_state_with_repo_name(self):
-        """Verify for state with repo name"""
+    def test_newer_format_state_with_repo_name(self):
+        """Verify that `translate_state` return the state itself if a newer format bookmark is found."""
         state = {
             "bookmarks": {
                 "org/test-repo" : {
@@ -44,9 +44,9 @@ class TestTranslateState(unittest.TestCase):
         final_state = translate_state(state, self.catalog, ["org/test-repo", "org/test-repo2"])
         self.assertEqual(state, dict(final_state))
 
-    def test_state_without_repo_name(self):
-        """Verify for state without repo name"""
-        state = {
+    def test_older_format_state_without_repo_name(self):
+        """Verify that `translate_state` migrate each stream's bookmark into the repo name"""
+        older_format_state = {
             "bookmarks": {
                 "comments": {"since": "2019-01-01T00:00:00Z"}
             }
@@ -61,7 +61,7 @@ class TestTranslateState(unittest.TestCase):
                     }
             }
         }
-        final_state = translate_state(state, self.catalog, ["org/test-repo", "org/test-repo2"])
+        final_state = translate_state(older_format_state, self.catalog, ["org/test-repo", "org/test-repo2"])
         self.assertEqual(expected_state, dict(final_state))
 
     def test_with_empty_state(self):
@@ -73,7 +73,7 @@ class TestTranslateState(unittest.TestCase):
 
     def test_state_with_no_previous_repo_name_newer_format_bookmark(self):
         """Verify that `translate_state` return the existing state if all existing repo unselected in the current sync."""
-        state = {
+        newer_format_state = {
             "bookmarks": {
                 "org/test-repo" : {
                         "comments": {"since": "2019-01-01T00:00:00Z"}
@@ -81,12 +81,12 @@ class TestTranslateState(unittest.TestCase):
                 "org/test-repo2" : {}
             }
         }
-        final_state = translate_state(state, self.catalog, ["org/test-repo3", "org/test-repo4"])
-        self.assertEqual(state, dict(final_state))
+        final_state = translate_state(newer_format_state, self.catalog, ["org/test-repo3", "org/test-repo4"])
+        self.assertEqual(newer_format_state, dict(final_state))
 
     def test_state_with_no_previous_repo_name_old_format_bookmark(self):
         """Verify that `translate_state` migrate each stream's bookmark into the repo name"""
-        state = {
+        older_format_state = {
             "bookmarks": {
                 "comments": {"since": "2019-01-01T00:00:00Z"}
             }
@@ -101,7 +101,7 @@ class TestTranslateState(unittest.TestCase):
                     }
             }
         }
-        final_state = translate_state(state, self.catalog, ["org/test-repo3", "org/test-repo4"])
+        final_state = translate_state(older_format_state, self.catalog, ["org/test-repo3", "org/test-repo4"])
         self.assertEqual(expected_state, dict(final_state))
 
 class TestGetStreamsToSync(unittest.TestCase):

--- a/tests/unittests/test_get_streams_and_state_translate.py
+++ b/tests/unittests/test_get_streams_and_state_translate.py
@@ -71,6 +71,21 @@ class TestTranslateState(unittest.TestCase):
 
         self.assertEqual({}, dict(final_state))
 
+    def test_state_with_no_previous_repo_name(self):
+        """
+        Verify that `translate_state` return the existing state if all existing repos are unselected in the current sync.
+        """
+        state = {
+            "bookmarks": {
+                "org/test-repo" : {
+                        "comments": {"since": "2019-01-01T00:00:00Z"}
+                    },
+                "org/test-repo2" : {}
+            }
+        }
+        final_state = translate_state(state, self.catalog, ["org/test-repo3", "org/test-repo4"])
+        self.assertEqual(state, dict(final_state))
+
 class TestGetStreamsToSync(unittest.TestCase):
     """
     Testcase for `get_stream_to_sync` in sync


### PR DESCRIPTION
# Description of change
- Added logic to return the existing state if all existing repos are unselected for the next sync.
- Added unit test to verify the same.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
