### PR TITLE
Use page size of 100 for issue_events

### DIFF
--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -683,7 +683,7 @@ class IssueEvents(IncrementalOrderedStream):
     replication_method = "INCREMENTAL"
     replication_keys = "created_at"
     key_properties = ["id"]
-    path = "issues/events?sort=created_at&direction=desc"
+    path = "issues/events?sort=created_at&direction=desc&per_page=100"
 
 class Events(IncrementalStream):
     '''


### PR DESCRIPTION
# Description of change
The [issue events](https://docs.github.com/en/rest/issues/events#list-issue-events-for-a-repository) endpoint has a max page size of 100 which will allow more records to be loaded per page thus allowing more records to be loaded before hitting the github rate limit

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
