### PR TITLE
Adding a 10 second break to ensure the retry is not done before the API key reset

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -128,9 +128,10 @@ def raise_for_error(resp, source, stream, client, should_skip_404):
 def calculate_seconds(epoch):
     """
     Calculate the seconds to sleep before making a new request.
+    Note: a 10 second break to ensure the retry is not done before the reset
     """
     current = time.time()
-    return int(round((epoch - current), 0))
+    return int(round((epoch - current), 0)) + 10
 
 def rate_throttling(response, max_sleep_seconds):
     """

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -128,10 +128,9 @@ def raise_for_error(resp, source, stream, client, should_skip_404):
 def calculate_seconds(epoch):
     """
     Calculate the seconds to sleep before making a new request.
-    Note: a 10 second break to ensure the retry is not done before the reset
     """
     current = time.time()
-    return int(round((epoch - current), 0)) + 10
+    return int(round((epoch - current), 0))
 
 def rate_throttling(response, max_sleep_seconds):
     """

--- a/tests/unittests/test_rate_limit.py
+++ b/tests/unittests/test_rate_limit.py
@@ -31,7 +31,7 @@ class TestRateLimit(unittest.TestCase):
         rate_throttling(resp, DEFAULT_SLEEP_SECONDS)
 
         # Verify `time.sleep` is called with expected seconds in response
-        mocked_sleep.assert_called_with(120)
+        mocked_sleep.assert_called_with(130)
         self.assertTrue(mocked_sleep.called)
 
 
@@ -49,7 +49,7 @@ class TestRateLimit(unittest.TestCase):
         # Verify exception is raised with proper message
         with self.assertRaises(tap_github.client.RateLimitExceeded) as e:
             rate_throttling(resp, DEFAULT_SLEEP_SECONDS)
-        self.assertEqual(str(e.exception), "API rate limit exceeded, please try after 601 seconds.")
+        self.assertEqual(str(e.exception), "API rate limit exceeded, please try after 611 seconds.")
 
 
     def test_rate_limit_not_exceeded(self, mocked_sleep):

--- a/tests/unittests/test_rate_limit.py
+++ b/tests/unittests/test_rate_limit.py
@@ -31,7 +31,7 @@ class TestRateLimit(unittest.TestCase):
         rate_throttling(resp, DEFAULT_SLEEP_SECONDS)
 
         # Verify `time.sleep` is called with expected seconds in response
-        mocked_sleep.assert_called_with(130)
+        mocked_sleep.assert_called_with(120)
         self.assertTrue(mocked_sleep.called)
 
 
@@ -49,7 +49,7 @@ class TestRateLimit(unittest.TestCase):
         # Verify exception is raised with proper message
         with self.assertRaises(tap_github.client.RateLimitExceeded) as e:
             rate_throttling(resp, DEFAULT_SLEEP_SECONDS)
-        self.assertEqual(str(e.exception), "API rate limit exceeded, please try after 611 seconds.")
+        self.assertEqual(str(e.exception), "API rate limit exceeded, please try after 601 seconds.")
 
 
     def test_rate_limit_not_exceeded(self, mocked_sleep):

--- a/tests/unittests/test_rate_limit.py
+++ b/tests/unittests/test_rate_limit.py
@@ -2,10 +2,12 @@ import tap_github
 from tap_github.client import rate_throttling, GithubException
 import unittest
 from unittest import mock
+from math import ceil
 import time
 import requests
 
 DEFAULT_SLEEP_SECONDS = 600
+DEFAULT_MIN_RATE_LIMIT = 0
 def api_call():
     return requests.get("https://api.github.com/rate_limit")
 
@@ -25,13 +27,13 @@ class TestRateLimit(unittest.TestCase):
         mocked_sleep.side_effect = None
 
         resp = api_call()
-        resp.headers["X-RateLimit-Reset"] = int(round(time.time(), 0)) + 120
+        resp.headers["X-RateLimit-Reset"] = int(ceil(time.time())) + 120
         resp.headers["X-RateLimit-Remaining"] = 0
 
-        rate_throttling(resp, DEFAULT_SLEEP_SECONDS)
+        rate_throttling(resp, DEFAULT_SLEEP_SECONDS, DEFAULT_MIN_RATE_LIMIT)
 
         # Verify `time.sleep` is called with expected seconds in response
-        mocked_sleep.assert_called_with(120)
+        mocked_sleep.assert_called_with(121)
         self.assertTrue(mocked_sleep.called)
 
 
@@ -43,13 +45,13 @@ class TestRateLimit(unittest.TestCase):
         mocked_sleep.side_effect = None
 
         resp = api_call()
-        resp.headers["X-RateLimit-Reset"] = int(round(time.time(), 0)) + 601
+        resp.headers["X-RateLimit-Reset"] = int(ceil(time.time())) + 601
         resp.headers["X-RateLimit-Remaining"] = 0
 
         # Verify exception is raised with proper message
         with self.assertRaises(tap_github.client.RateLimitExceeded) as e:
-            rate_throttling(resp, DEFAULT_SLEEP_SECONDS)
-        self.assertEqual(str(e.exception), "API rate limit exceeded, please try after 601 seconds.")
+            rate_throttling(resp, DEFAULT_SLEEP_SECONDS, DEFAULT_MIN_RATE_LIMIT)
+        self.assertEqual(str(e.exception), "API rate limit exceeded, please try after 602 seconds.")
 
 
     def test_rate_limit_not_exceeded(self, mocked_sleep):
@@ -60,13 +62,29 @@ class TestRateLimit(unittest.TestCase):
         mocked_sleep.side_effect = None
 
         resp = api_call()
-        resp.headers["X-RateLimit-Reset"] = int(round(time.time(), 0)) + 10
+        resp.headers["X-RateLimit-Reset"] = int(ceil(time.time())) + 10
         resp.headers["X-RateLimit-Remaining"] = 5
 
-        rate_throttling(resp, DEFAULT_SLEEP_SECONDS)
+        rate_throttling(resp, DEFAULT_SLEEP_SECONDS, DEFAULT_MIN_RATE_LIMIT)
 
         # Verify that `time.sleep` is not called
         self.assertFalse(mocked_sleep.called)
+
+    def test_rate_limit_wait_with_min_rate_limit_defined(self, mocked_sleep):
+        """
+        Test `rate_throttling` if sleep time does exceed limit with a different value for the `min_rate_limit`
+        """
+
+        mocked_sleep.side_effect = None
+
+        resp = api_call()
+        resp.headers["X-RateLimit-Reset"] = int(ceil(time.time())) + 10
+        resp.headers["X-RateLimit-Remaining"] = 5
+
+        rate_throttling(resp, DEFAULT_SLEEP_SECONDS, min_rate_limit=5)
+
+        # Verify `time.sleep` is called
+        self.assertTrue(mocked_sleep.called)
 
     def test_rate_limt_header_not_found(self, mocked_sleep):
         """
@@ -76,7 +94,7 @@ class TestRateLimit(unittest.TestCase):
         resp.headers={}
         
         with self.assertRaises(GithubException) as e:
-            rate_throttling(resp, DEFAULT_SLEEP_SECONDS)
+            rate_throttling(resp, DEFAULT_SLEEP_SECONDS, DEFAULT_MIN_RATE_LIMIT)
         
         # Verifying the message formed for the invalid base URL
         self.assertEqual(str(e.exception), "The API call using the specified base url was unsuccessful. Please double-check the provided base URL.")


### PR DESCRIPTION
# Description of change
Every time the API rate limit was reached, the retry attempt was triggered before resetting the API token, which causes a new exception that causes the extract to fail and it need to restart again from the beginning.

The idea of this PR is just to add 10 seconds break to ensure that the retry is not done before the API key reset.

# Manual QA steps
test_rate_limited updated:
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/7281460/197237060-c41e34bb-92a5-4a0c-8449-1acc17b5dc46.png">
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
