### PR TITLE
Fix incorrect format of discussion_url field in releases schema

### DIFF
--- a/tap_github/schemas/releases.json
+++ b/tap_github/schemas/releases.json
@@ -186,8 +186,7 @@
       "format": "date-time"
     },
     "discussion_url": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     }
   }
 }


### PR DESCRIPTION
# Description of change
The field `discussion_url` in `releases` schema is incorrectly defined as `date-time` causing some issues in the extraction.

# Manual QA steps
 - Manually tested with Meltano.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
