### PR TITLE
TDL-239782 Remove `files` and `stats` fields from commit-related schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 2.0.6
+  * Remove `files` and `stats` fields from `commits` endpoint as they are not returned without fetching individual commmits [#198](https://github.com/singer-io/tap-github/pull/198)
+  * Remove `files` and `stats` fields from `pr-commits` endpoint as they are not documented and not returned
+  * Update tests accordingly
+
 # 2.0.5
   * Remove date-time format from the field discussion_url in releases schema [#196](https://github.com/singer-io/tap-github/pull/196)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='2.0.5',
+      version='2.0.6',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/schemas/commits.json
+++ b/tap_github/schemas/commits.json
@@ -44,38 +44,6 @@
         }
       }
     },
-    "files": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "filename": {
-            "type": ["null", "string"]
-          },
-          "additions": {
-            "type": ["null", "number"]
-          },
-          "deletions": {
-            "type": ["null", "number"]
-          },
-          "changes": {
-            "type": ["null", "number"]
-          },
-          "status": {
-            "type": ["null", "string"]
-          },
-          "raw_url": {
-            "type": ["null", "string"]
-          },
-          "blob_url": {
-            "type": ["null", "string"]
-          },
-          "patch": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
     "html_url": {
       "type": ["null", "string"]
     },
@@ -258,20 +226,6 @@
     },
     "author": {
       "$ref": "shared/user.json#/"
-    },
-    "stats": {
-      "type": ["null", "object"],
-      "properties": {
-        "additions": {
-          "type": ["null", "integer"]
-        },
-        "deletions": {
-          "type": ["null", "integer"]
-        },
-        "total": {
-          "type": ["null", "integer"]
-        }
-      }
     }
   },
   "additionalProperties": false

--- a/tap_github/schemas/pr_commits.json
+++ b/tap_github/schemas/pr_commits.json
@@ -35,44 +35,6 @@
           }
         }
       },
-      "files": {
-        "type": ["null","array"],
-        "items": {
-          "type": ["null","object"],
-          "properties": {
-            "filename": {
-              "type": ["null","string"]
-            },
-            "additions": {
-              "type": ["null","number"]
-            },
-            "deletions": {
-              "type": ["null","number"]
-            },
-            "changes": {
-              "type": ["null","number"]
-            },
-            "status": {
-              "type": ["null","string"]
-            },
-            "raw_url": {
-              "type": ["null","string"]
-            },
-            "blob_url": {
-              "type": ["null","string"]
-            },
-            "contents_url": {
-              "type": ["null","string"]
-            },
-            "sha": {
-              "type": ["null","string"]
-            },
-            "patch": {
-              "type": ["null","string"]
-            }
-          }
-        }
-      },
       "html_url": {
         "type": ["null", "string"],
         "description": "The HTML URL to the commit"
@@ -300,20 +262,6 @@
       },
       "author": {
         "$ref": "shared/user.json#/"
-      },
-      "stats": {
-        "type": ["null", "object"],
-        "properties": {
-          "additions": {
-            "type": ["null", "integer"]
-          },
-          "deletions": {
-            "type": ["null", "integer"]
-          },
-          "total": {
-            "type": ["null", "integer"]
-          }
-        }
       },
       "updated_at": {
         "type": ["null", "string"],

--- a/tests/test_github_all_fields.py
+++ b/tests/test_github_all_fields.py
@@ -20,15 +20,9 @@ KNOWN_MISSING_FIELDS = {
         'project_id'
     },
     'commits': {
-        'files',
         'pr_id',
         'id',
         'pr_number',
-        'stats',
-    },
-    'pr_commits': {
-        'files',
-        'stats'
     },
     'review_comments': {
         'assignees',


### PR DESCRIPTION
# Description of change
See PR title. updates all_fields known missing fields to remove these.

# Manual QA steps
 - tested w/ client connection; ran all fields test (passing)
 
# Risks
 - confusion for people who had those fields selected
 
# Rollback steps
 - revert this branch
