### PR TITLE
TDL-24380 - Don't rely on dictionary order to grab PKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 3.0.0
+  * Allow all python versions to grab the correct key_properties/PK value [#199](https://github.com/singer-io/tap-github/pull/199)
+
 # 2.0.6
   * Remove `files` and `stats` fields from `commits` endpoint as they are not returned without fetching individual commmits [#198](https://github.com/singer-io/tap-github/pull/198)
   * Remove `files` and `stats` fields from `pr-commits` endpoint as they are not documented and not returned

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='2.0.6',
+      version='3.0.0',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/discover.py
+++ b/tap_github/discover.py
@@ -1,4 +1,5 @@
 import singer
+from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_github.schema import get_schemas
 
@@ -24,13 +25,12 @@ def discover(client):
             LOGGER.error('type schema_dict: %s', type(schema_dict))
             raise err
 
-        root_mdata = [x for x in mdata if x['breadcrumb'] == ()]
-        key_properties = root_mdata[0]['metadata'].get('table-key-properties')
+        key_properties = metadata.to_map(mdata).get((), {}).get('table-key-properties')
 
         catalog.streams.append(CatalogEntry(
             stream=stream_name,
             tap_stream_id=stream_name,
-            key_properties= key_properties,
+            key_properties=key_properties,
             schema=schema,
             metadata=mdata
         ))

--- a/tap_github/discover.py
+++ b/tap_github/discover.py
@@ -24,7 +24,9 @@ def discover(client):
             LOGGER.error('type schema_dict: %s', type(schema_dict))
             raise err
 
-        key_properties = mdata[0]['metadata'].get('table-key-properties')
+        root_mdata = [x for x in mdata if x['breadcrumb'] == ()]
+        key_properties = root_mdata[0]['metadata'].get('table-key-properties')
+
         catalog.streams.append(CatalogEntry(
             stream=stream_name,
             tap_stream_id=stream_name,


### PR DESCRIPTION
# Description of change
Python versions prior to 3.6 do not maintain insertion order for dictionaries. If the root object of metadata is not the first element in the metadata list, the `key_properties` field in the schema will not be set correctly.

This change will allow all python versions to grab the correct value for the PK.

# Manual QA steps
 - Schema includes the correct key_properties/PK for all streams
 
# Risks
 - If the PK was not in the schema for a stream, this will change the PK. Tables in the destination will need to updated to handle the new PK.
 
# Rollback steps
 - revert this branch
