### PR TITLE
Re-add `files` and `stats` properties to `PrCommits` stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 3.0.1
+  * Re-add `files` and `stats` properties to `PrCommits` stream
+
 # 3.0.0
   * Allow all python versions to grab the correct key_properties/PK value [#199](https://github.com/singer-io/tap-github/pull/199)
   * Dependabot update [#193](https://github.com/singer-io/tap-github/pull/193)

--- a/tap_github/schemas/pr_commits.json
+++ b/tap_github/schemas/pr_commits.json
@@ -35,6 +35,44 @@
           }
         }
       },
+      "files": {
+        "type": ["null","array"],
+        "items": {
+          "type": ["null","object"],
+          "properties": {
+            "filename": {
+              "type": ["null","string"]
+            },
+            "additions": {
+              "type": ["null","number"]
+            },
+            "deletions": {
+              "type": ["null","number"]
+            },
+            "changes": {
+              "type": ["null","number"]
+            },
+            "status": {
+              "type": ["null","string"]
+            },
+            "raw_url": {
+              "type": ["null","string"]
+            },
+            "blob_url": {
+              "type": ["null","string"]
+            },
+            "contents_url": {
+              "type": ["null","string"]
+            },
+            "sha": {
+              "type": ["null","string"]
+            },
+            "patch": {
+              "type": ["null","string"]
+            }
+          }
+        }
+      },
       "html_url": {
         "type": ["null", "string"],
         "description": "The HTML URL to the commit"
@@ -262,6 +300,20 @@
       },
       "author": {
         "$ref": "shared/user.json#/"
+      },
+      "stats": {
+        "type": ["null", "object"],
+        "properties": {
+          "additions": {
+            "type": ["null", "integer"]
+          },
+          "deletions": {
+            "type": ["null", "integer"]
+          },
+          "total": {
+            "type": ["null", "integer"]
+          }
+        }
       },
       "updated_at": {
         "type": ["null", "string"],


### PR DESCRIPTION
# Description of change
The purpose of this PR is to re-add the `files` and `stats` properties to the `PrCommits` stream.

As explained in [this issue](https://github.com/singer-io/tap-github/issues/202), these properties were removed from both `Commits` and `PrCommits` streams in this [PR](https://github.com/dlouseiro/tap-github-singer-io/commit/dc309b65e66e5a88355c546e81540280d7c7b4ab). However, these properties are available when[ listing commits for a PR](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-commits-on-a-pull-request), unlike what happens for the `Commits` stream, where these properties are not available when [listing commits ](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits), but only available when one fetches an [individual commit](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit).