### PR TITLE
remove uri format from the events url field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 3.0.1
+  * Remove URI format of `/payload/issue/labels/url` field from `events` stream [#205](https://github.com/singer-io/tap-github/pull/205)
+
 # 3.0.0
   * Allow all python versions to grab the correct key_properties/PK value [#199](https://github.com/singer-io/tap-github/pull/199)
   * Dependabot update [#193](https://github.com/singer-io/tap-github/pull/193)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='3.0.0',
+      version='3.0.1',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/schemas/events.json
+++ b/tap_github/schemas/events.json
@@ -173,8 +173,7 @@
                     "type": ["null", "string"]
                   },
                   "url": {
-                    "type": ["null", "string"],
-                    "format": "uri"
+                    "type": ["null", "string"]
                   },
                   "name": {
                     "type": ["null", "string"]


### PR DESCRIPTION
# Description of change
- Fixes below error ([TDL-24898](https://jira.talendforge.org/browse/TDL-24898)):
  `2024-02-20 21:15:43,447Z   main - INFO Exit status is: Discovery succeeded. Tap failed with code -15. Target failed with code 1 and error message: "Error persisting data to Stitch: 400: {'error': 'Record 0 for table events did not conform to schema:\n#: #: no subschema matched out of the total 2 subschemas\n#/payload: #: no subschema matched out of the total 2 subschemas\n#/payload/issue: #: no subschema matched out of the total 3 subschemas\n#/payload/issue/labels: #: no subschema matched out of the total 2 subschemas\n#/payload/issue/labels/1: #: no subschema matched out of the total 2 subschemas\n#/payload/issue/labels/1/url: #: no subschema matched out of the total 2 subschemas\n#/payload/issue/labels/1/url: [https://api.github.com/repos/abcdefgh/API/labels/Review%20effort%20[1-5]:%203] is not a valid URI\n#/payload/issue/labels/1/url: expected: null, found: String\n#/payload/issue/labels/1: expected: null, found: JSONObject\n#/payload/issue/labels: expected: null, found: JSONArray\n#/payload/issue: expected type: String, found: JSONObject\n#/payload/issue: expected: null, found: JSONObject\n#/payload: expected: null, found: JSONObject\n#: expected: null, found: JSONObject\n'}".`
  
  And, It looks like the **_events_** endpoint has a field called _**url**_ . The [system expects](https://github.com/singer-io/tap-github/blob/master/tap_github/schemas/events.json#L175-L177) that field to either be null or be a string formatted as a URI. In this case, the field is there, but the value is failing the URI format validation.
  Hence, removing the URI format restriction for this particular field to accept the string value coming through url field.

 - Release changes in setup.py and CHANGELOG.md

# Manual QA steps
 - 
 
# Risks
 - low (as mentioned [here](https://github.com/stitchdata/loader-common/blob/fe656432f8612d12c3b84ca143bd69dde162c3df/src/clj/com/stitchdata/loader_common/marshal.clj#L151), we are not applying any specific validation through URI format)
 
# Rollback steps
 - revert this branch
