### PR TITLE
Remove int64 format

### DIFF
--- a/tap_github/schemas/events.json
+++ b/tap_github/schemas/events.json
@@ -166,8 +166,7 @@
                 "type": ["null", "object"],
                 "properties": {
                   "id": {
-                    "type": ["null", "integer"],
-                    "format": "int64"
+                    "type": ["null", "integer"]
                   },
                   "node_id": {
                     "type": ["null", "string"]


### PR DESCRIPTION
# Description of change
Updates the events schema to remove an extraneous format on an integer datatype that happens to be causing validation failures in testing.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
