### PR TITLE
Tdl 26656 transform state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 3.1.0
+  * Transform state to allow stream level resets [#212](https://github.com/singer-io/tap-github/pull/212)
+
 # 3.0.1
   * Remove URI format of `/payload/issue/labels/url` field from `events` stream [#205](https://github.com/singer-io/tap-github/pull/205)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='3.0.1',
+      version='3.1.0',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -9,7 +9,7 @@ def get_bookmark(state, repo, stream_name, bookmark_key, start_date):
     """
     Return bookmark value if available in the state otherwise return start date
     """
-    repo_stream_dict = bookmarks.get_bookmark(state, repo, stream_name)
+    repo_stream_dict = bookmarks.get_bookmark(state, stream_name, repo)
     if repo_stream_dict:
         return repo_stream_dict.get(bookmark_key)
 
@@ -119,7 +119,7 @@ class Stream:
 
         # If the stream is selected, write the bookmark.
         if stream in selected_streams:
-            singer.write_bookmark(state, repo_path, stream_obj.tap_stream_id, {"since": bookmark_value})
+            singer.write_bookmark(state, stream_obj.tap_stream_id, repo_path, {"since": bookmark_value})
 
         # For the each child, write the bookmark if it is selected.
         for child in stream_obj.children:
@@ -205,14 +205,14 @@ class Stream:
 
 class FullTableStream(Stream):
     def sync_endpoint(self,
-                        client,
-                        state,
-                        catalog,
-                        repo_path,
-                        start_date,
-                        selected_stream_ids,
-                        stream_to_sync
-                        ):
+                      client,
+                      state,
+                      catalog,
+                      repo_path,
+                      start_date,
+                      selected_stream_ids,
+                      stream_to_sync
+                      ):
         """
         A common function sync full table streams.
         """

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -115,9 +115,10 @@ def translate_state(state, catalog, repositories):
 
         # If the state contains a bookmark for `repo_a` and `repo_b` and the user deselects these both repos and adds another repo
         # then in that case this function was returning an empty state. Now this change will return the existing state instead of the empty state.
-        if key not in stream_names and key not in repositories:
-            # Return the existing state if all repos from the previous state are deselected(not found) in the current sync.
-            return state
+        for repo in state['bookmarks'][key].keys():
+            if repo not in stream_names and repo not in repositories:
+                # Return the existing state if all repos from the previous state are deselected(not found) in the current sync.
+                return state
 
     for stream in catalog['streams']:
         stream_name = stream['tap_stream_id']

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -82,10 +82,11 @@ def translate_state(state, catalog, repositories):
         }
       }
     }
-    In QCDI, the stream keys must be the second key after bookmarks in
-    order for standardized table-level resets to function correctly. This
-    function should be called at the start of each run to ensure that the
-    state is properly converted to the new format:
+
+    The stream keys must be the second key after bookmarks in order for
+    standardized table-level resets to function correctly. This function
+    should be called at the start of each run to ensure that the state
+    is properly converted to the new format:
     {
       "bookmarks": {
         "commits" : {

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -65,8 +65,9 @@ def get_ordered_repos(state, repositories):
 
 def translate_state(state, catalog, repositories):
     '''
-    The tap supports multiple repos. This was the previous format
-    of bookmarks in state, which has the stream keys under the repo:
+    The tap supports multiple repositories. Previously, the state format
+    for bookmarks included stream keys nested under each repository, as
+    shown below:
     {
       "bookmarks": {
         "singer-io/tap-adwords": {
@@ -81,10 +82,10 @@ def translate_state(state, catalog, repositories):
         }
       }
     }
-    In qcdi the stream keys need to be after bookmarks for standardized
-    table level resets to occur. This function should be called at the
-    beginning of each run to ensure the state is translated to the new
-    format:
+    In QCDI, the stream keys must be the second key after bookmarks in
+    order for standardized table-level resets to function correctly. This
+    function should be called at the start of each run to ensure that the
+    state is properly converted to the new format:
     {
       "bookmarks": {
         "commits" : {

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -126,41 +126,6 @@ def translate_state(state, catalog, repositories):
 
     for key in previous_state_keys:
         # Loop through each key of `bookmarks` available in the previous state.
-
-        # Case 1:
-        # Older connections `bookmarks` contain stream names so check if it is the stream name or not.
-        # If the previous state's key is found in the stream name list then continue to check other keys. Because we want
-        # to migrate each stream's bookmark into the repo name as mentioned below:
-        # Example: {`bookmarks`: {`stream_a`: `bookmark_a`}} to {`bookmarks`: {`repo_a`: {`stream_a`: `bookmark_a`}}}
-
-        # Case 2:
-        # Check if the key is available in the list of currently selected repo's list or not. Newer format `bookmarks` contain repo names.
-        # Return the state if the previous state's key is not found in the repo name list or stream name list.
-
-        # If the state contains a bookmark for `repo_a` and `repo_b` and the user deselects these both repos and adds another repo
-        # then in that case this function was returning an empty state. Now this change will return the existing state instead of the empty state.
-
-        # old state
-        # {
-        #     "bookmarks": {
-        #         "org/test-repo3": {
-        #             "comments": {"since": "2019-01-01T00:00:00Z"}
-        #          }
-        #     }
-        # }
-        # for each repo, check each stream under the repo. If the stream is not in stream names or repositories return state.
-        # stream should always be in stream_names
-
-        # new state
-        # {
-        #     "bookmarks": {
-        #         "comments" : {
-        #             "org/test-repo3": {"since": "2019-01-01T00:00:00Z"},
-        #         },
-        #     }
-        # }
-        # for each stream, loop over repos in stream. If the repo is not a stream name (it wont be) or is not is the list of repos, reutrn state. This could happen, and is the case we are checking for. If the repositories are not selected, new ones will get added the new bookmark way.
-
         for inner_key in state['bookmarks'][key].keys():
             if inner_key not in stream_names and inner_key not in repositories:
                 # Return the existing state if all repos from the previous state are deselected(not found) in the current sync.

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -122,10 +122,10 @@ def translate_state(state, catalog, repositories):
     for stream in catalog['streams']:
         stream_name = stream['tap_stream_id']
         for repo in repositories:
-            if bookmarks.get_bookmark(state, repo, stream_name):
+            if bookmarks.get_bookmark(state, stream_name, repo):
                 return state
-            if bookmarks.get_bookmark(state, stream_name, 'since'):
-                new_state['bookmarks'][repo][stream_name]['since'] = bookmarks.get_bookmark(state, stream_name, 'since')
+            if bookmarks.get_bookmark(state, repo, stream_name):
+                new_state['bookmarks'][stream_name][repo] = bookmarks.get_bookmark(state, repo, stream_name)
 
     return new_state
 

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -54,17 +54,8 @@ def get_ordered_stream_list(currently_syncing, streams_to_sync):
     return stream_list
 
 def get_ordered_repos(state, repositories):
-    """Get an ordered list of remaining repos to sync followed by synced repos.
-
-    The tap supports multiple repos, this is the previous format
-    of bookmarks in state, which has the stream keys under the repo:
-
-
-    In qcdi the stream keys need to be after bookmarks, for standardized
-    table level resets to occur. so, this function should be called at the
-    beginning of each run to ensure the state is translated to the new
-    format:
-
+    """
+    Get an ordered list of remaining repos to sync followed by synced repos.
     """
     syncing_repo = state.get("currently_syncing_repo")
     if syncing_repo in repositories:

--- a/tests/test_github_all_fields.py
+++ b/tests/test_github_all_fields.py
@@ -58,7 +58,6 @@ KNOWN_MISSING_FIELDS = {
     },
     'issues': {
         'body_text',
-        'closed_by',
         'body_html'
     },
     'releases': {

--- a/tests/test_github_bookmarks.py
+++ b/tests/test_github_bookmarks.py
@@ -27,21 +27,23 @@ class TestGithubBookmarks(TestGithubBase):
         timedelta_by_stream["commits"] = [7, 0, 0]
 
         repo = self.get_properties().get('repository')
+        #stream_to_calculated_state = {repo: {stream: "" for stream in current_state['bookmarks'][repo].keys()}}
+        stream_to_calculated_state = current_state.copy()['bookmarks']
 
-        stream_to_calculated_state = {repo: {stream: "" for stream in current_state['bookmarks'][repo].keys()}}
-        for stream, state in current_state['bookmarks'][repo].items():
-            state_key, state_value = next(iter(state.keys())), next(iter(state.values()))
-            state_as_datetime = dateutil.parser.parse(state_value)
+        for stream in current_state['bookmarks'].keys():
+            for repo, state in current_state['bookmarks'][stream].items():
+                state_key, state_value = next(iter(state.keys())), next(iter(state.values()))
+                state_as_datetime = dateutil.parser.parse(state_value)
 
-            days, hours, minutes = timedelta_by_stream[stream]
+                days, hours, minutes = timedelta_by_stream[stream]
 
-            start_date_as_datetime = dateutil.parser.parse(start_date)
-            calculated_state_as_datetime = start_date_as_datetime + datetime.timedelta(days=days, hours=hours, minutes=minutes)
+                start_date_as_datetime = dateutil.parser.parse(start_date)
+                calculated_state_as_datetime = start_date_as_datetime + datetime.timedelta(days=days, hours=hours, minutes=minutes)
 
-            state_format = '%Y-%m-%dT%H:%M:%SZ'
-            calculated_state_formatted = datetime.datetime.strftime(calculated_state_as_datetime, state_format)
+                state_format = '%Y-%m-%dT%H:%M:%SZ'
+                calculated_state_formatted = datetime.datetime.strftime(calculated_state_as_datetime, state_format)
 
-            stream_to_calculated_state[repo][stream] = {state_key: calculated_state_formatted}
+                stream_to_calculated_state[stream][repo] = {state_key: calculated_state_formatted}
 
         return stream_to_calculated_state
 
@@ -69,7 +71,6 @@ class TestGithubBookmarks(TestGithubBase):
         ##########################################################################
         ### First Sync
         ##########################################################################
-
         conn_id = connections.ensure_connection(self, original_properties=True)
 
         # Run in check mode
@@ -94,8 +95,8 @@ class TestGithubBookmarks(TestGithubBase):
                                                             first_sync_records,
                                                             expected_replication_keys,
                                                             first_sync_start_date)
-        for repo, new_state in simulated_states.items():
-            new_states['bookmarks'][repo] = new_state
+        for stream, new_state in simulated_states.items():
+            new_states['bookmarks'][stream] = new_state
         menagerie.set_state(conn_id, new_states)
 
         ##########################################################################
@@ -125,20 +126,21 @@ class TestGithubBookmarks(TestGithubBase):
                 second_sync_messages = [record.get('data') for record in
                                         second_sync_records.get(stream, {'messages': []}).get('messages')
                                         if record.get('action') == 'upsert']
-                first_bookmark_key_value = first_sync_bookmarks.get('bookmarks', {}).get(repo, {stream: None}).get(stream)
-                second_bookmark_key_value = second_sync_bookmarks.get('bookmarks', {}).get(repo, {stream: None}).get(stream)
+                first_bookmark_key_value = first_sync_bookmarks.get('bookmarks', {}).get(stream, {repo: None}).get(repo)
+                second_bookmark_key_value = second_sync_bookmarks.get('bookmarks', {}).get(stream, {repo: None}).get(repo)
 
 
                 if expected_replication_method == self.INCREMENTAL:
                     # Collect information specific to incremental streams from syncs 1 & 2
                     replication_key = next(iter(expected_replication_keys[stream]))
+
                     first_bookmark_value = first_bookmark_key_value.get('since')
                     second_bookmark_value = second_bookmark_key_value.get('since')
 
                     first_bookmark_value_ts = self.dt_to_ts(first_bookmark_value, self.BOOKMARK_FORMAT)
                     second_bookmark_value_ts = self.dt_to_ts(second_bookmark_value, self.BOOKMARK_FORMAT)
 
-                    simulated_bookmark_value = self.dt_to_ts(new_states['bookmarks'][repo][stream]['since'], self.BOOKMARK_FORMAT)
+                    simulated_bookmark_value = self.dt_to_ts(new_states['bookmarks'][stream][repo]['since'], self.BOOKMARK_FORMAT)
 
                     # Verify the first sync sets a bookmark of the expected form
                     self.assertIsNotNone(first_bookmark_key_value)
@@ -159,7 +161,6 @@ class TestGithubBookmarks(TestGithubBase):
                     for record in first_sync_messages:
                         # Verify the first sync bookmark value is the max replication key value for a given stream
                         replication_key_value = self.dt_to_ts(record.get(replication_key), replication_key_format)
-
                         self.assertLessEqual(
                             replication_key_value, first_bookmark_value_ts,
                             msg="First sync bookmark was set incorrectly, a record with a greater replication-key value was synced."

--- a/tests/test_github_bookmarks.py
+++ b/tests/test_github_bookmarks.py
@@ -1,6 +1,7 @@
 import datetime
 import dateutil.parser
 import pytz
+import copy
 
 from tap_tester import runner, menagerie, connections
 
@@ -28,7 +29,7 @@ class TestGithubBookmarks(TestGithubBase):
 
         repo = self.get_properties().get('repository')
         #stream_to_calculated_state = {repo: {stream: "" for stream in current_state['bookmarks'][repo].keys()}}
-        stream_to_calculated_state = current_state.copy()['bookmarks']
+        stream_to_calculated_state = copy.deepcopy(current_state)['bookmarks']
 
         for stream in current_state['bookmarks'].keys():
             for repo, state in current_state['bookmarks'][stream].items():

--- a/tests/test_github_interrupted_sync_remove_stream.py
+++ b/tests/test_github_interrupted_sync_remove_stream.py
@@ -189,8 +189,8 @@ class TestGithubInterruptedSyncRemoveStream(TestGithubBase):
 
                         else:
                             # Verify full table streams do not save bookmarked values after a successful sync
-                            self.assertNotIn(stream, full_sync_bookmark.keys())
-                            self.assertNotIn(stream, final_bookmark.keys())
+                            self.assertNotIn(stream, full_sync_state["bookmarks"].keys())
+                            self.assertNotIn(stream, final_state["bookmarks"].keys())
 
                             # Verify first and second sync have the same records
                             self.assertEqual(full_record_count, interrupted_record_count)

--- a/tests/test_github_interrupted_sync_remove_stream.py
+++ b/tests/test_github_interrupted_sync_remove_stream.py
@@ -37,7 +37,7 @@ class TestGithubInterruptedSyncRemoveStream(TestGithubBase):
         expected_replication_methods = self.expected_replication_method()
         expected_replication_keys = self.expected_bookmark_keys()
         repo_key = "_sdc_repository"
-        
+
         start_date = self.dt_to_ts(self.get_properties().get("start_date"), self.BOOKMARK_FORMAT)
 
         # Run a discovery job
@@ -54,14 +54,14 @@ class TestGithubInterruptedSyncRemoveStream(TestGithubBase):
         # Acquire records from target output
         full_sync_records = runner.get_records_from_target_output()
         full_sync_state = menagerie.get_state(conn_id)
-        
+
         # Create new connection for another sync
         conn_id_2 = connections.ensure_connection(self)
 
         # Add a stream between syncs
         streams_to_test = streams_to_test - {removed_stream}
         found_catalogs = self.run_and_verify_check_mode(conn_id_2)
-        
+
         test_catalogs = [catalog for catalog in found_catalogs
                            if catalog.get('stream_name') in streams_to_test]
 
@@ -75,23 +75,25 @@ class TestGithubInterruptedSyncRemoveStream(TestGithubBase):
             "currently_syncing": "pull_requests",
             "currently_syncing_repo": "singer-io/test-repo",
             "bookmarks": {
-                "singer-io/singer-python": {
-                    "issues": {
+                "issues": {
+                    "singer-io/singer-python": {
                         "since": "2022-06-22T13:32:42Z"
                     },
-                    "pull_requests": {
-                        "since": "2022-06-22T13:32:42Z"
-                    },
-                    "issue_events": {
-                        "since": "2022-06-22T13:32:42Z"
+                    "singer-io/test-repo": {
+                        "since": "2022-07-14T07:47:21Z"
                     }
                 },
-                "singer-io/test-repo": {
-                    "issues": {
-                        "since": "2022-07-14T07:47:21Z"
+                "pull_requests": {
+                    "singer-io/singer-python": {
+                        "since": "2022-06-22T13:32:42Z"
                     },
-                    "pull_requests": {
+                    "singer-io/test-repo": {
                         "since": "2022-07-13T07:47:21Z"
+                    }
+                },
+                "issue_events": {
+                    "singer-io/singer-python": {
+                        "since": "2022-06-22T13:32:42Z"
                     }
                 }
             }
@@ -116,23 +118,19 @@ class TestGithubInterruptedSyncRemoveStream(TestGithubBase):
             # Verify bookmarks are saved
             self.assertIsNotNone(final_state.get('bookmarks'))
 
-        for repository in self.get_properties().get("repository").split():
-            with self.subTest(repository=repository):
-            
-                full_sync_bookmark = full_sync_state["bookmarks"][repository]
-                final_bookmark = final_state["bookmarks"][repository]
-                interrupted_repo_bookmark = interrupted_state["bookmarks"][repository]
-                
-                for stream in list(streams_to_test) + [removed_stream]:
-                    with self.subTest(stream=stream):
-                        
+        for stream in list(streams_to_test) + [removed_stream]:
+            with self.subTest(stream=stream):
+
+                for repository in self.get_properties().get("repository").split():
+                    with self.subTest(repository=repository):
+
                         # Expected values
                         expected_replication_method = expected_replication_methods[stream]
                         expected_primary_keys = list(self.expected_primary_keys()[stream])
 
                         # Gather results
                         full_records = [message['data'] for message in
-                                        full_sync_records.get(stream, {}).get('messages', []) 
+                                        full_sync_records.get(stream, {}).get('messages', [])
                                         if message['data'][repo_key] == repository]
                         full_record_count = len(full_records)
 
@@ -145,12 +143,16 @@ class TestGithubInterruptedSyncRemoveStream(TestGithubBase):
                             self.assertNotIn(stream, interrupted_sync_records.keys())
 
                         if expected_replication_method == self.INCREMENTAL:
+                            full_sync_bookmark = full_sync_state["bookmarks"][stream]
+
                             expected_replication_key = next(iter(expected_replication_keys[stream]))
-                            full_sync_stream_bookmark = self.dt_to_ts(full_sync_bookmark.get(stream, {}).get("since"), self.BOOKMARK_FORMAT)
-                                
-                            if stream in interrupted_repo_bookmark.keys():
-                                interrupted_bookmark = self.dt_to_ts(interrupted_repo_bookmark[stream]["since"], self.BOOKMARK_FORMAT)
-                                final_sync_stream_bookmark = self.dt_to_ts(final_bookmark.get(stream, {}).get("since"), self.BOOKMARK_FORMAT)
+                            full_sync_stream_bookmark = self.dt_to_ts(full_sync_bookmark.get(repository, {}).get("since"), self.BOOKMARK_FORMAT)
+                            interrupted_repo_bookmark = interrupted_state["bookmarks"][stream]
+
+                            if repository in interrupted_repo_bookmark.keys():
+                                final_bookmark = final_state["bookmarks"][stream]
+                                interrupted_bookmark = self.dt_to_ts(interrupted_repo_bookmark[repository]["since"], self.BOOKMARK_FORMAT)
+                                final_sync_stream_bookmark = self.dt_to_ts(final_bookmark.get(repository, {}).get("since"), self.BOOKMARK_FORMAT)
 
                                 if stream != removed_stream:
 

--- a/tests/test_github_pagination.py
+++ b/tests/test_github_pagination.py
@@ -34,6 +34,7 @@ class GitHubPaginationTest(TestGithubBase):
             'team_members',
             'collaborators',
             'assignees',
+            'events',
         }
 
         # For some streams RECORD count were not > 30 in same test-repo.

--- a/tests/test_github_start_date.py
+++ b/tests/test_github_start_date.py
@@ -32,20 +32,20 @@ class GithubStartDateTest(TestGithubBase):
         # generate data for 'events' stream
         self.generate_data()
 
-        date_1 = '2020-04-01T00:00:00Z'
-        date_2 = '2021-10-08T00:00:00Z'
+        date_1 = '2023-04-01T00:00:00Z'
+        date_2 = '2024-10-08T00:00:00Z'
         expected_stream_1  = {'commits'}
         self.run_test(date_1, date_2, expected_stream_1)
 
-        date_2 = '2022-07-13T00:00:00Z'
+        date_2 = '2024-07-13T00:00:00Z'
         expected_stream_2  = {'issue_milestones'}
         self.run_test(date_1, date_2, expected_stream_2)
 
-        date_2 = '2022-05-06T00:00:00Z'
+        date_2 = '2024-05-06T00:00:00Z'
         expected_stream_3  = {'pr_commits', 'review_comments', 'reviews'}
         self.run_test(date_1, date_2, expected_stream_3)
 
-        date_2 = '2022-01-27T00:00:00Z'
+        date_2 = '2024-01-27T00:00:00Z'
         expected_stream_4 = self.expected_streams().difference(
             expected_stream_1,
             expected_stream_2,
@@ -58,10 +58,10 @@ class GithubStartDateTest(TestGithubBase):
         # `issues` doesn't have enough data in this range, so we skip it too
         self.run_test(date_1, date_2, expected_stream_4)
 
-        date_3 = '2023-01-27T00:00:00Z'
+        date_3 = '2024-01-27T00:00:00Z'
         self.run_test(date_1, date_3, {"issues"})
 
-        date_4 = '2023-01-01T00:00:00Z'
+        date_4 = '2024-01-01T00:00:00Z'
         self.run_test(date_1, date_4, {'pull_requests'})
 
         # As per the Documentation: https://docs.github.com/en/rest/reference/activity#events
@@ -209,7 +209,6 @@ class GithubStartDateTest(TestGithubBase):
                     self.assertTrue(primary_keys_sync_2.issubset(primary_keys_sync_1))
 
                 else:
-
                     # Verify that the 2nd sync with a later start date replicates the same number of
                     # records as the 1st sync.
                     self.assertEqual(record_count_sync_2, record_count_sync_1)

--- a/tests/unittests/test_get_streams_and_state_translate.py
+++ b/tests/unittests/test_get_streams_and_state_translate.py
@@ -33,11 +33,10 @@ class TestTranslateState(unittest.TestCase):
     def test_newer_format_state_with_repo_name(self):
         """Verify that `translate_state` return the state itself if a newer format bookmark is found."""
         state = {
-            "bookmarks": {
-                "org/test-repo" : {
-                        "comments": {"since": "2019-01-01T00:00:00Z"}
+            "bookmarks" : {
+                "comments" : {
+                    "org/test-repo": {"since": "2019-01-01T00:00:00Z"},
                     },
-                "org/test-repo2" : {}
             }
         }
 
@@ -48,17 +47,18 @@ class TestTranslateState(unittest.TestCase):
         """Verify that `translate_state` migrate each stream's bookmark into the repo name"""
         older_format_state = {
             "bookmarks": {
-                "comments": {"since": "2019-01-01T00:00:00Z"}
-            }
-        }
-        expected_state =  {
-            "bookmarks": {
                 "org/test-repo" : {
                         "comments": {"since": "2019-01-01T00:00:00Z"}
                     },
                 "org/test-repo2" : {
                         "comments": {"since": "2019-01-01T00:00:00Z"}
                     }
+            }
+        }
+        expected_state =  {
+            "bookmarks": {
+                "comments": {"org/test-repo" : {"since": "2019-01-01T00:00:00Z"},
+                            "org/test-repo2" : {"since": "2019-01-01T00:00:00Z"}},
             }
         }
         final_state = translate_state(older_format_state, self.catalog, ["org/test-repo", "org/test-repo2"])
@@ -75,10 +75,9 @@ class TestTranslateState(unittest.TestCase):
         """Verify that `translate_state` return the existing state if all existing repo unselected in the current sync."""
         newer_format_state = {
             "bookmarks": {
-                "org/test-repo" : {
-                        "comments": {"since": "2019-01-01T00:00:00Z"}
+                "comments" : {
+                        "org/test-repo": {"since": "2019-01-01T00:00:00Z"}
                     },
-                "org/test-repo2" : {}
             }
         }
         final_state = translate_state(newer_format_state, self.catalog, ["org/test-repo3", "org/test-repo4"])
@@ -88,17 +87,16 @@ class TestTranslateState(unittest.TestCase):
         """Verify that `translate_state` migrate each stream's bookmark into the repo name"""
         older_format_state = {
             "bookmarks": {
-                "comments": {"since": "2019-01-01T00:00:00Z"}
+                "org/test-repo3": {
+                    "comments": {"since": "2019-01-01T00:00:00Z"}
+                 }
             }
         }
         expected_state = {
             "bookmarks": {
-                "org/test-repo3" : {
-                        "comments": {"since": "2019-01-01T00:00:00Z"}
-                    },
-                "org/test-repo4" : {
-                        "comments": {"since": "2019-01-01T00:00:00Z"}
-                    }
+                "comments" : {
+                    "org/test-repo3": {"since": "2019-01-01T00:00:00Z"},
+                },
             }
         }
         final_state = translate_state(older_format_state, self.catalog, ["org/test-repo3", "org/test-repo4"])

--- a/tests/unittests/test_get_streams_and_state_translate.py
+++ b/tests/unittests/test_get_streams_and_state_translate.py
@@ -64,6 +64,31 @@ class TestTranslateState(unittest.TestCase):
         final_state = translate_state(older_format_state, self.catalog, ["org/test-repo", "org/test-repo2"])
         self.assertEqual(expected_state, dict(final_state))
 
+    def test_older_format_state_without_repo_name_multiple_streams(self):
+        """Verify that `translate_state` migrate each stream's bookmark into the repo name"""
+        older_format_state = {
+            "bookmarks": {
+                "org/test-repo" : {
+                    "comments": {"since": "2019-01-01T00:00:00Z"},
+                    "issue_events": {"updated_at": "2019-01-01T00:00:00Z"}
+                },
+                "org/test-repo2" : {
+                    "comments": {"since": "2019-01-01T00:00:00Z"},
+                    "issue_events": {"updated_at": "2019-01-01T00:00:00Z"}
+                }
+            }
+        }
+        expected_state =  {
+            "bookmarks": {
+                "comments": {"org/test-repo" : {"since": "2019-01-01T00:00:00Z"},
+                             "org/test-repo2" : {"since": "2019-01-01T00:00:00Z"}},
+                "issue_events": {"org/test-repo": {"updated_at": "2019-01-01T00:00:00Z"},
+                                 "org/test-repo2": {"updated_at": "2019-01-01T00:00:00Z"}}
+            }
+        }
+        final_state = translate_state(older_format_state, self.catalog, ["org/test-repo", "org/test-repo2"])
+        self.assertEqual(expected_state, final_state)
+
     def test_with_empty_state(self):
         """Verify for empty state"""
 
@@ -83,6 +108,23 @@ class TestTranslateState(unittest.TestCase):
         }
         final_state = translate_state(newer_format_state, self.catalog, ["org/test-repo3", "org/test-repo4"])
         self.assertEqual(newer_format_state, dict(final_state))
+
+    def test_state_with_no_previous_repo_name_newer_format_bookmark_multiple_streams(self):
+        """Verify that `translate_state` return the existing state if all existing repo unselected in the current sync."""
+        newer_format_state = {
+            "bookmarks": {
+                "comments" : {
+                    "org/test-repo": {"since": "2019-01-01T00:00:00Z"},
+                    "org/test-repo2": {"since": "2019-01-01T00:00:00Z"}
+                },
+                "issue_events" : {
+                    "org/test-repo": {"updated_at": "2019-01-01T00:00:00Z"},
+                    "org/test-repo2": {"updated_at": "2019-01-01T00:00:00Z"}
+                },
+            }
+        }
+        final_state = translate_state(newer_format_state, self.catalog, ["org/test-repo3", "org/test-repo4"])
+        self.assertEqual(newer_format_state, final_state)
 
     def test_state_with_no_previous_repo_name_old_format_bookmark(self):
         """Verify that `translate_state` migrate each stream's bookmark into the repo name"""

--- a/tests/unittests/test_get_streams_and_state_translate.py
+++ b/tests/unittests/test_get_streams_and_state_translate.py
@@ -76,7 +76,8 @@ class TestTranslateState(unittest.TestCase):
         newer_format_state = {
             "bookmarks": {
                 "comments" : {
-                        "org/test-repo": {"since": "2019-01-01T00:00:00Z"}
+                    "org/test-repo": {"since": "2019-01-01T00:00:00Z"},
+                    "org/test-repo2": {"since": "2019-01-01T00:00:00Z"}
                     },
             }
         }

--- a/tests/unittests/test_sync_endpoint.py
+++ b/tests/unittests/test_sync_endpoint.py
@@ -29,7 +29,7 @@ class TestSyncEndpoints(unittest.TestCase):
                                                            {"id": 2, "created_at": "2019-01-04T00:00:00Z"}]),
                                               MockResponse([{"id": 3, "created_at": "2019-01-03T00:00:00Z"},
                                                            {"id": 4, "created_at": "2019-01-02T00:00:00Z"}])]
-        expected_state = {'bookmarks': {'tap-github': {'events': {'since': '2019-01-04T00:00:00Z'}}}}
+        expected_state = {'bookmarks': {'events': {'tap-github': {'since': '2019-01-04T00:00:00Z'}}}}
         test_client = GithubClient(self.config)
         final_state = test_stream.sync_endpoint(test_client, {}, self.catalog, "tap-github", "2018-01-02T00:00:00Z", ["events"], ['events'])
         
@@ -52,9 +52,9 @@ class TestSyncEndpoints(unittest.TestCase):
                                                            {"id": 2, "created_at": "2019-01-04T00:00:00Z"}]),
                                               MockResponse([{"id": 3, "created_at": "2019-01-03T00:00:00Z"},
                                                            {"id": 4, "created_at": "2019-01-02T00:00:00Z"}])]
-        mock_state = {'bookmarks': {'tap-github': {'events': {'since': '2019-01-02T00:00:00Z'}}}}
+        mock_state = {'bookmarks': {'events': {'tap-github': {'since': '2019-01-02T00:00:00Z'}}}}
         
-        expected_state = {'bookmarks': {'tap-github': {'events': {'since': '2019-01-04T00:00:00Z'}}}}
+        expected_state = {'bookmarks': {'events': {'tap-github': {'since': '2019-01-04T00:00:00Z'}}}}
         test_client = GithubClient(self.config)
         final_state = test_stream.sync_endpoint(test_client, mock_state, self.catalog, "tap-github", "2018-01-02T00:00:00Z", ["events"], ['events'])
         


### PR DESCRIPTION
# Description of change
Tap-github supports multiple repositories. The previous bookmark format for tap was:
`{bookmarks {repository {stream_name ...}}}`
In order to support stream level resets, we need to switch the bookmark format to:
`{bookmarks {stream_name {repository ...}}}`

This pr update the `translate_state` function to convert old bookmarks into the new state. New connections will have the new format automatically. 

# Manual QA steps
 - Created a connection on master with the old bookmark format. Switched to this branch, ran another sync and checked that the format changed. Then, I deselected all the repos in use and added a new repo to make sure state is not dropped.
 
# Risks
 - in 2018 multiple repo support was added [here](https://github.com/singer-io/tap-github/pull/33), and bookmarks were converted from `{bookmarks {stream_name {bookmark_values...}}}` to `{bookmarks {repository {stream_name ...}}}`. There are 13 connection that still have the old old bookmark format, but they are all either on non-active accounts or paused an require a major version bump. In this update the old old bookmark format is not accommodated, it should be impossible for a connection with that format to run this code, but if I missed something and it happens the tap would error. 
 - I fixed the 'events' data generation in the pagination tap-tester test. It will now create and close an issue on each run in singer-io/test-repo. This could create a lot of closed issues over time. 
 
# Rollback steps
 - investigate the issue, a new pr will likely need to be created to handle different state formats

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
