### PR TITLE
SAC-27669: Remove Sunset Projects, ProjectCards, and ProjectColumns streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 3.2.0
+  * Removes the `Projects`, `ProjectCards`, and `ProjectColumns`
+    streams as they've been sunset by Github [#218](https://github.com/singer-io/tap-github/pull/218)
+
 # 3.1.0
   * Transform state to allow stream level resets [#212](https://github.com/singer-io/tap-github/pull/212)
 
@@ -38,7 +42,7 @@
   * Implement currently syncing for repos and streams [#171](https://github.com/singer-io/tap-github/pull/171) [#174](https://github.com/singer-io/tap-github/pull/174)
   * Implement custom exception handling and backoff for 5xx error [#166](https://github.com/singer-io/tap-github/pull/166)
   * Support of custom domain [#172](https://github.com/singer-io/tap-github/pull/172)
-  * Sync teams at organization level [#173](https://github.com/singer-io/tap-github/pull/173) 
+  * Sync teams at organization level [#173](https://github.com/singer-io/tap-github/pull/173)
   * Update integration test suite [#167](https://github.com/singer-io/tap-github/pull/167)
 
 # 1.10.4

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='3.1.0',
+      version='3.2.0',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -517,46 +517,6 @@ class PullRequests(IncrementalOrderedStream):
     children = ['reviews', 'review_comments', 'pr_commits']
     pk_child_fields = ["number"]
 
-class ProjectCards(IncrementalStream):
-    '''
-    https://docs.github.com/en/rest/reference/projects#list-project-cards
-    '''
-    tap_stream_id = "project_cards"
-    replication_method = "INCREMENTAL"
-    replication_keys = "updated_at"
-    key_properties = ["id"]
-    path = "projects/columns/{}/cards"
-    tap_stream_id = "project_cards"
-    parent = 'project_columns'
-    id_keys = ['id']
-
-class ProjectColumns(IncrementalStream):
-    '''
-    https://docs.github.com/en/rest/reference/projects#list-project-columns
-    '''
-    tap_stream_id = "project_columns"
-    replication_method = "INCREMENTAL"
-    replication_keys = "updated_at"
-    key_properties = ["id"]
-    path = "projects/{}/columns"
-    children = ["project_cards"]
-    parent = "projects"
-    id_keys = ['id']
-    has_children = True
-
-class Projects(IncrementalStream):
-    '''
-    https://docs.github.com/en/rest/reference/projects#list-repository-projects
-    '''
-    tap_stream_id = "projects"
-    replication_method = "INCREMENTAL"
-    replication_keys = "updated_at"
-    key_properties = ["id"]
-    path = "projects?state=all"
-    tap_stream_id = "projects"
-    children = ["project_columns"]
-    child_objects = [ProjectColumns()]
-
 class TeamMemberships(FullTableStream):
     '''
     https://docs.github.com/en/rest/reference/teams#get-team-membership-for-a-user
@@ -753,9 +713,6 @@ STREAMS = {
     "events": Events,
     "commit_comments": CommitComments,
     "issue_milestones": IssueMilestones,
-    "projects": Projects,
-    "project_columns": ProjectColumns,
-    "project_cards": ProjectCards,
     "pull_requests": PullRequests,
     "reviews": Reviews,
     "review_comments": ReviewComments,

--- a/tests/base.py
+++ b/tests/base.py
@@ -130,24 +130,6 @@ class TestGithubBase(unittest.TestCase):
                 self.BOOKMARK: {"updated_at"},
                 self.OBEYS_START_DATE: True
             },
-            # "project_cards": {
-            #     self.PRIMARY_KEYS: {"id"},
-            #     self.REPLICATION_METHOD: self.INCREMENTAL,
-            #     self.BOOKMARK: {"updated_at"},
-            #     self.OBEYS_START_DATE: True
-            # },
-            # "project_columns": {
-            #     self.PRIMARY_KEYS: {"id"},
-            #     self.REPLICATION_METHOD: self.INCREMENTAL,
-            #     self.BOOKMARK: {"updated_at"},
-            #     self.OBEYS_START_DATE: True
-            # },
-            # "projects": {
-            #     self.PRIMARY_KEYS: {"id"},
-            #     self.REPLICATION_METHOD: self.INCREMENTAL,
-            #     self.BOOKMARK: {"updated_at"},
-            #     self.OBEYS_START_DATE: True
-            # },
             "pull_requests": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
@@ -284,7 +266,7 @@ class TestGithubBase(unittest.TestCase):
 
         found_catalog_names = set(map(lambda c: c['stream_name'], found_catalogs))
         LOGGER.info(found_catalog_names)
-        self.assertSetEqual(self.expected_streams(), found_catalog_names - {"projects", "project_cards", "project_columns"}, msg="discovered schemas do not match")
+        self.assertSetEqual(self.expected_streams(), found_catalog_names, msg="discovered schemas do not match")
         LOGGER.info("discovered schemas are OK")
 
         return found_catalogs

--- a/tests/test_github_all_fields.py
+++ b/tests/test_github_all_fields.py
@@ -22,12 +22,6 @@ KNOWN_MISSING_FIELDS = {
         "size",
         "type"
     },
-    # 'project_cards': {
-    #     'name',
-    #     'cards_url',
-    #     'column_name',
-    #     'project_id'
-    # },
     'commits': {
         'pr_id',
         'id',
@@ -87,10 +81,6 @@ KNOWN_MISSING_FIELDS = {
     'teams': {
         'permissions'
     },
-    # 'projects': {
-    #     'organization_permission',
-    #     'private'
-    # },
     'assignees': {
         'email',
         'starred_at',

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -26,8 +26,7 @@ class TestGithubSync(TestGithubBase):
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
         catalogs = [catalog
-                    for catalog in found_catalogs
-                    if catalog['stream_name'] not in {'project_cards', 'projects', 'project_columns'}]
+                    for catalog in found_catalogs]
         self.perform_and_verify_table_and_field_selection(conn_id, catalogs)
 
         record_count_by_stream = self.run_and_verify_sync(conn_id)

--- a/tests/unittests/test_get_streams_and_state_translate.py
+++ b/tests/unittests/test_get_streams_and_state_translate.py
@@ -153,9 +153,6 @@ class TestGetStreamsToSync(unittest.TestCase):
     def get_catalog(self, parent=False, mid_child = False, child = False):
         return {
             "streams": [
-                get_stream_catalog("projects", selected_in_metadata=parent),
-                get_stream_catalog("project_columns", selected_in_metadata=mid_child),
-                get_stream_catalog("project_cards", selected_in_metadata=child),
                 get_stream_catalog("teams", selected_in_metadata=parent),
                 get_stream_catalog("team_members", selected_in_metadata=mid_child),
                 get_stream_catalog("team_memberships", selected_in_metadata=child),
@@ -164,9 +161,9 @@ class TestGetStreamsToSync(unittest.TestCase):
         }
 
     @parameterized.expand([
-        ['test_parent_selected', ["assignees", "projects", "teams"], True, False, False],
-        ['test_mid_child_selected', ["projects", "project_columns", "teams", "team_members"], False, True, False],
-        ['test_lowest_child_selected', ["projects", "project_columns", "project_cards", "teams", "team_members", "team_memberships"], False, False, True]
+        ['test_parent_selected', ["assignees", "teams"], True, False, False],
+        ['test_mid_child_selected', ["teams", "team_members"], False, True, False],
+        ['test_lowest_child_selected', ["teams", "team_members", "team_memberships"], False, False, True]
     ])
     def test_stream_selection(self, name, expected_streams, is_parent, is_mid_child, is_child):
         """Test that if an only child or mid-child is selected in the catalog, then `get_stream_to_sync` returns the parent stream also"""

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -145,18 +145,19 @@ class TestWriteBookmark(unittest.TestCase):
         self.assertIn(mock_write_bookmark.mock_calls[1], expected_calls)
         self.assertIn(mock_write_bookmark.mock_calls[2], expected_calls)
 
-    def test_nested_child(self, mock_write_bookmark):
-        """
-        Test for the stream if the nested child is selected
-        """
-        test_stream = Projects()
-        test_stream.write_bookmarks("projects", ["project_cards"],
-                                     "2022-04-01T00:00:00Z", "org/test-repo", self.state)
+    # Projects parent and child streams were deprecated by Github. Test commented out 07/21/25
+    # def test_nested_child(self, mock_write_bookmark):
+    #     """
+    #     Test for the stream if the nested child is selected
+    #     """
+    #     test_stream = Projects()
+    #     test_stream.write_bookmarks("projects", ["project_cards"],
+    #                                  "2022-04-01T00:00:00Z", "org/test-repo", self.state)
 
-        # Verify `write_bookmark` is called for all selected streams
-        self.assertEqual(mock_write_bookmark.call_count, 1)
-        mock_write_bookmark.assert_called_with(mock.ANY, "project_cards",
-                                               mock.ANY, {"since": "2022-04-01T00:00:00Z"})
+    #     # Verify `write_bookmark` is called for all selected streams
+    #     self.assertEqual(mock_write_bookmark.call_count, 1)
+    #     mock_write_bookmark.assert_called_with(mock.ANY, "project_cards",
+    #                                            mock.ANY, {"since": "2022-04-01T00:00:00Z"})
 
 
 class TestGetChildUrl(unittest.TestCase):

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from tap_github.streams import Comments, ProjectColumns, Projects, Reviews, TeamMemberships, Teams, PullRequests, get_schema, get_child_full_url, get_bookmark
+from tap_github.streams import Comments, Reviews, TeamMemberships, Teams, PullRequests, get_schema, get_child_full_url, get_bookmark
 from parameterized import parameterized
 
 
@@ -20,41 +20,41 @@ class TestGetSchema(unittest.TestCase):
         # Verify returned schema is same as exected schema
         self.assertEqual(get_schema(catalog, "comments"), expected_schema)
 
+# Projects parent and child streams were deprecated by Github. Test commented out 07/21/25
+# class TestGetBookmark(unittest.TestCase):
+#     """
+#     Test `get_bookmark` method
+#     """
 
-class TestGetBookmark(unittest.TestCase):
-    """
-    Test `get_bookmark` method
-    """
+#     test_stream = Comments()
 
-    test_stream = Comments()
+#     def test_without_stream_key(self):
+#         """
+#         Test if the state does not contain a repo path
+#         """
+#         state = {
+#             "bookmarks": {
+#                 "org/test-repo": {
+#                     "projects" : {"since": "2022-01-01T00:00:00Z"}
+#                 }
+#             }
+#         }
+#         returned_bookmark = get_bookmark(state, "org/test-repo", "projects", "since", "2021-01-01T00:00:00Z")
+#         self.assertEqual(returned_bookmark, "2021-01-01T00:00:00Z")
 
-    def test_without_stream_key(self):
-        """
-        Test if the state does not contain a repo path
-        """
-        state = {
-            "bookmarks": {
-                "org/test-repo": {
-                    "projects" : {"since": "2022-01-01T00:00:00Z"}
-                }
-            }
-        }
-        returned_bookmark = get_bookmark(state, "org/test-repo", "projects", "since", "2021-01-01T00:00:00Z")
-        self.assertEqual(returned_bookmark, "2021-01-01T00:00:00Z")
-
-    def test_with_streams_key(self):
-        """
-        Test if the state does contains a repo path
-        """
-        state = {
-            "bookmarks": {
-                "projects": {
-                    "org/test-repo": {"since": "2022-01-01T00:00:00Z"}
-                }
-            }
-        }
-        returned_bookmark = get_bookmark(state, "org/test-repo", "projects", "since", "2021-01-01T00:00:00Z")
-        self.assertEqual(returned_bookmark, "2022-01-01T00:00:00Z")
+#     def test_with_streams_key(self):
+#         """
+#         Test if the state does contains a repo path
+#         """
+#         state = {
+#             "bookmarks": {
+#                 "projects": {
+#                     "org/test-repo": {"since": "2022-01-01T00:00:00Z"}
+#                 }
+#             }
+#         }
+#         returned_bookmark = get_bookmark(state, "org/test-repo", "projects", "since", "2021-01-01T00:00:00Z")
+#         self.assertEqual(returned_bookmark, "2022-01-01T00:00:00Z")
 
 class TestBuildUrl(unittest.TestCase):
     """
@@ -84,9 +84,6 @@ class GetMinBookmark(unittest.TestCase):
     start_date = "2020-04-01T00:00:00Z"
     state = {
         "bookmarks": {
-            "projects": {"org/test-repo" : {"since": "2022-03-29T00:00:00Z"}},
-            "project_columns": {"org/test-repo" : {"since": "2022-03-01T00:00:00Z"}},
-            "project_cards": {"org/test-repo" : {"since": "2022-03-14T00:00:00Z"}},
             "pull_requests": {"org/test-repo" : {"since": "2022-04-01T00:00:00Z"}},
             "review_comments": {"org/test-repo" : {"since": "2022-03-01T00:00:00Z"}},
             "pr_commits": {"org/test-repo" : {"since": "2022-02-01T00:00:00Z"}},
@@ -97,8 +94,8 @@ class GetMinBookmark(unittest.TestCase):
     @parameterized.expand([
         ["test_multiple_children", PullRequests, "pull_requests", ["pull_requests","review_comments", "pr_commits"], "2022-04-01T00:00:00Z", "2022-02-01T00:00:00Z"],
         ["test_children_with_only_parent_selected", PullRequests, "pull_requests", ["pull_requests"], "2022-04-01T00:00:00Z", "2022-04-01T00:00:00Z"],
-        ["test_for_mid_child_in_stream", Projects, "projects", ["projects", "project_columns"], "2022-03-29T00:00:00Z", "2022-03-01T00:00:00Z"],
-        ["test_nested_child_bookmark", Projects, "projects", ["projects", "project_cards"], "2022-03-29T00:00:00Z", "2022-03-14T00:00:00Z"]
+        # ["test_for_mid_child_in_stream", Projects, "projects", ["projects", "project_columns"], "2022-03-29T00:00:00Z", "2022-03-01T00:00:00Z"],
+        # ["test_nested_child_bookmark", Projects, "projects", ["projects", "project_cards"], "2022-03-29T00:00:00Z", "2022-03-14T00:00:00Z"]
     ])
     def test_multiple_children(self, name, stream_class, stream_name, stream_to_sync, current_date, expected_bookmark):
         """
@@ -120,9 +117,6 @@ class TestWriteBookmark(unittest.TestCase):
 
     state = {
         "bookmarks": {
-            "projects": {"org/test-repo" : {"since": "2021-03-29T00:00:00Z"}},
-            "project_columns": {"org/test-repo" : {"since": "2021-03-01T00:00:00Z"}},
-            "project_cards": {"org/test-repo" : {"since": "2021-03-14T00:00:00Z"}},
             "pull_requests": {"org/test-repo" : {"since": "2021-04-01T00:00:00Z"}},
             "review_comments": {"org/test-repo" : {"since": "2021-03-01T00:00:00Z"}},
             "pr_commits": {"org/test-repo" : {"since": "2021-02-01T00:00:00Z"}},
@@ -172,7 +166,7 @@ class TestGetChildUrl(unittest.TestCase):
     domain = 'https://api.github.com'
 
     @parameterized.expand([
-        ["test_child_stream", ProjectColumns, "org1/test-repo", "https://api.github.com/projects/1309875/columns", None, (1309875,)],
+        #["test_child_stream", ProjectColumns, "org1/test-repo", "https://api.github.com/projects/1309875/columns", None, (1309875,)],
         ["test_child_is_repository", Reviews, "org1/test-repo", "https://api.github.com/repos/org1/test-repo/pulls/11/reviews", (11,), None],
         ["test_child_is_organization", TeamMemberships, "org1", "https://api.github.com/orgs/org1/teams/dev-team/memberships/demo-user-1", ("dev-team",), ("demo-user-1",)]
     ])

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -35,10 +35,7 @@ class TestSyncFunctions(unittest.TestCase):
         Test sync function with only all parents selected
         """
 
-        mock_catalog = {"streams": [
-            get_stream_catalog("projects", True),
-            get_stream_catalog("pull_requests", True)
-        ]}
+        mock_catalog = {"streams": [get_stream_catalog("pull_requests", True)]}
 
         client = mock.Mock()
         client.extract_repos_from_config.return_value = (["test-repo"], set())
@@ -48,10 +45,9 @@ class TestSyncFunctions(unittest.TestCase):
         sync(client, {'start_date': ""}, {}, mock_catalog)
 
         # Verify write schema is called for selected streams
-        self.assertEqual(mock_write_schemas.call_count, 2)
+        self.assertEqual(mock_write_schemas.call_count, 1)
 
-        self.assertEqual(mock_write_schemas.mock_calls[0], mock.call("projects", mock.ANY, mock.ANY))
-        self.assertEqual(mock_write_schemas.mock_calls[1], mock.call("pull_requests", mock.ANY, mock.ANY))
+        self.assertEqual(mock_write_schemas.mock_calls[0], mock.call("pull_requests", mock.ANY, mock.ANY))
 
     @mock.patch("tap_github.streams.IncrementalOrderedStream.sync_endpoint")
     def test_sync_only_child(self, mock_inc_ordered, mock_incremental, mock_write_schemas, mock_write_state):
@@ -60,9 +56,6 @@ class TestSyncFunctions(unittest.TestCase):
         """
 
         mock_catalog = {"streams": [
-            get_stream_catalog("projects"),
-            get_stream_catalog("project_columns"),
-            get_stream_catalog("project_cards", True),
             get_stream_catalog("pull_requests"),
             get_stream_catalog("review_comments", True)
         ]}
@@ -75,10 +68,9 @@ class TestSyncFunctions(unittest.TestCase):
         sync(client, {'start_date': "2019-01-01T00:00:00Z"}, {}, mock_catalog)
 
         # Verify write schema is called for selected streams
-        self.assertEqual(mock_write_schemas.call_count, 2)
+        self.assertEqual(mock_write_schemas.call_count, 1)
 
-        self.assertEqual(mock_write_schemas.mock_calls[0], mock.call("projects", mock.ANY, mock.ANY))
-        self.assertEqual(mock_write_schemas.mock_calls[1], mock.call("pull_requests", mock.ANY, mock.ANY))
+        self.assertEqual(mock_write_schemas.mock_calls[0], mock.call("pull_requests", mock.ANY, mock.ANY))
 
     @mock.patch("tap_github.streams.FullTableStream.sync_endpoint")
     def test_sync_only_mid_child(self, mock_full_table, mock_incremental, mock_write_schemas, mock_write_state):
@@ -87,9 +79,6 @@ class TestSyncFunctions(unittest.TestCase):
         """
 
         mock_catalog = {"streams": [
-            get_stream_catalog("projects"),
-            get_stream_catalog("project_columns", True),
-            get_stream_catalog("project_cards"),
             get_stream_catalog("teams"),
             get_stream_catalog("team_members", True),
             get_stream_catalog("team_memberships")
@@ -103,15 +92,14 @@ class TestSyncFunctions(unittest.TestCase):
         sync(client, {'start_date': ""}, {}, mock_catalog)
 
         # Verify write schema is called for selected streams
-        self.assertEqual(mock_write_schemas.call_count, 2)
+        self.assertEqual(mock_write_schemas.call_count, 1)
 
         self.assertEqual(mock_write_schemas.mock_calls[0], mock.call("teams", mock.ANY, mock.ANY))
-        self.assertEqual(mock_write_schemas.mock_calls[1], mock.call("projects", mock.ANY, mock.ANY))
 
     @mock.patch("tap_github.sync.get_stream_to_sync", return_value = [])
     @mock.patch("tap_github.sync.get_selected_streams", return_value = [])
     @mock.patch("tap_github.sync.update_currently_syncing_repo")
-    def test_no_streams_selected(self, mock_update_curr_sync, mock_selected_streams, mock_sync_streams, 
+    def test_no_streams_selected(self, mock_update_curr_sync, mock_selected_streams, mock_sync_streams,
                                  mock_incremental, mock_write_schemas, mock_write_state):
         """
         Test if no streams are selected then the state does not update,
@@ -124,8 +112,6 @@ class TestSyncFunctions(unittest.TestCase):
                     "currently_syncing": "teams"
                 }
         mock_catalog = {"streams": [
-            get_stream_catalog("projects"),
-            get_stream_catalog("project_columns", True),
             get_stream_catalog("teams"),
             get_stream_catalog("team_members", True)
         ]}
@@ -145,24 +131,24 @@ class TestSyncFunctions(unittest.TestCase):
         # Verify updated_currently_syncing_repo was not called
         self.assertFalse(mock_update_curr_sync.called)
 
+# Projects parent and child streams were deprecated by Github. Test commented out 07/21/25
+# @mock.patch("singer.write_schema")
+# class TestWriteSchemas(unittest.TestCase):
 
-@mock.patch("singer.write_schema")
-class TestWriteSchemas(unittest.TestCase):
+#     mock_catalog = {"streams": [
+#         get_stream_catalog("projects"),
+#         get_stream_catalog("project_columns"),
+#         get_stream_catalog("project_cards")
+#     ]}
 
-    mock_catalog = {"streams": [
-        get_stream_catalog("projects"),
-        get_stream_catalog("project_columns"),
-        get_stream_catalog("project_cards")
-    ]}
+#     def test_parents_selected(self, mock_write_schema):
+#         write_schemas("projects", self.mock_catalog, ["projects"])
+#         mock_write_schema.assert_called_with("projects", mock.ANY, mock.ANY)
 
-    def test_parents_selected(self, mock_write_schema):
-        write_schemas("projects", self.mock_catalog, ["projects"])
-        mock_write_schema.assert_called_with("projects", mock.ANY, mock.ANY)
+#     def test_mid_child_selected(self, mock_write_schema):
+#         write_schemas("project_columns", self.mock_catalog, ["project_columns"])
+#         mock_write_schema.assert_called_with("project_columns", mock.ANY, mock.ANY)
 
-    def test_mid_child_selected(self, mock_write_schema):
-        write_schemas("project_columns", self.mock_catalog, ["project_columns"])
-        mock_write_schema.assert_called_with("project_columns", mock.ANY, mock.ANY)
-
-    def test_nested_child_selected(self, mock_write_schema):
-        write_schemas("project_cards", self.mock_catalog, ["project_cards"])
-        mock_write_schema.assert_called_with("project_cards", mock.ANY, mock.ANY)
+#     def test_nested_child_selected(self, mock_write_schema):
+#         write_schemas("project_cards", self.mock_catalog, ["project_cards"])
+#         mock_write_schema.assert_called_with("project_cards", mock.ANY, mock.ANY)


### PR DESCRIPTION
# Description of change
Github [has sunset](https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/) the product functionality behind these streams and the API endpoints are now non-functional. This PR removes the affected streams and removes them from tests where applicable. Other tests are commented out as they may prove useful for revision with other child streams.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
