### PR TITLE
feat: add files and stats to PrCommits stream schema

### DIFF
--- a/tap_github/schemas/pr_commits.json
+++ b/tap_github/schemas/pr_commits.json
@@ -266,6 +266,77 @@
       "updated_at": {
         "type": ["null", "string"],
         "format": "date-time"
+      },
+      "stats": {
+        "type": ["null", "object"],
+        "additionalProperties": false,
+        "properties": {
+          "additions": {
+            "type": ["null", "integer"],
+            "description": "Number of additions in the commit"
+          },
+          "deletions": {
+            "type": ["null", "integer"],
+            "description": "Number of deletions in the commit"
+          },
+          "total": {
+            "type": ["null", "integer"],
+            "description": "Total number of changes in the commit"
+          }
+        }
+      },
+      "files": {
+        "type": ["null", "array"],
+        "items": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "sha": {
+              "type": ["null", "string"],
+              "description": "The file blob SHA"
+            },
+            "filename": {
+              "type": ["null", "string"],
+              "description": "The name of the file"
+            },
+            "status": {
+              "type": ["null", "string"],
+              "description": "The status of the file (added, removed, modified, renamed)"
+            },
+            "additions": {
+              "type": ["null", "integer"],
+              "description": "Number of additions in the file"
+            },
+            "deletions": {
+              "type": ["null", "integer"],
+              "description": "Number of deletions in the file"
+            },
+            "changes": {
+              "type": ["null", "integer"],
+              "description": "Total number of changes in the file"
+            },
+            "blob_url": {
+              "type": ["null", "string"],
+              "description": "The URL to view the blob for this file"
+            },
+            "raw_url": {
+              "type": ["null", "string"],
+              "description": "The URL to download the raw content of the file"
+            },
+            "contents_url": {
+              "type": ["null", "string"],
+              "description": "The URL to the file contents API endpoint"
+            },
+            "patch": {
+              "type": ["null", "string"],
+              "description": "The patch/diff of the changes to the file"
+            },
+            "previous_filename": {
+              "type": ["null", "string"],
+              "description": "The previous filename (for renamed files)"
+            }
+          }
+        }
       }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #202

Re-adds the `files` and `stats` properties to the PrCommits stream schema.

## Background

Unlike the regular Commits stream, the GitHub API for listing commits on a pull request **does** include `files` and `stats` in the response. These fields were previously removed from PrCommits because they were confused with the regular Commits stream where these fields are not available.

## Changes

Added to `pr_commits.json` schema:
- `stats`: Total additions, deletions, and changes per commit
- `files`: Array of file-level changes with detailed information:
  - File metadata (sha, filename, status, blob_url, raw_url, contents_url)
  - Change counts (additions, deletions, changes)
  - Patch/diff content
  - Previous filename (for renamed files)

## Value

This provides analytical value for understanding code changes at the commit level for PRs, including:
- Size of commits (total changes)
- Which files were modified in each commit
- Detailed diff statistics per file

See GitHub API docs: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-commits-on-a-pull-request