### PR TITLE
remove streams from catalog if not have permission and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 3.3.5
+  * Bump version for singer-python, requests, backoff to latest [#229](https://github.com/singer-io/tap-github/pull/229)
+
 # 3.3.4
   * Fix malformed URL causing 'since' filter to be dropped for Issues and Comments streams [#230](https://github.com/singer-io/tap-github/pull/230)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 # 3.4.0
-  * Include stream exclusion and bump version for singer-python, requests, backoff to latest [#229](https://github.com/singer-io/tap-github/pull/229)
+  * Exclude 403-forbidden streams from discovery [#229](https://github.com/singer-io/tap-github/pull/229)
+  * Bump dependencies for compliance
 
 # 3.3.4
   * Fix malformed URL causing 'since' filter to be dropped for Issues and Comments streams [#230](https://github.com/singer-io/tap-github/pull/230)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-# 3.3.5
-  * Bump version for singer-python, requests, backoff to latest [#229](https://github.com/singer-io/tap-github/pull/229)
+# 3.4.0
+  * Include stream exclusion and bump version for singer-python, requests, backoff to latest [#229](https://github.com/singer-io/tap-github/pull/229)
 
 # 3.3.4
   * Fix malformed URL causing 'since' filter to be dropped for Issues and Comments streams [#230](https://github.com/singer-io/tap-github/pull/230)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='3.3.5',
+      version='3.4.0',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,16 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='3.3.4',
+      version='3.3.5',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_github'],
       install_requires=[
-          'singer-python==5.12.1',
-          'requests==2.33.0',
-          'backoff==1.8.0'
+          'singer-python==6.8.0',
+          'requests==2.34.2',
+          'backoff==2.2.1'
       ],
       extras_require={
           'dev': [

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -249,11 +249,13 @@ class GithubClient:
             message = "HTTP-error-code: 404, Error: Please check the repository name \'{}\' or you do not have sufficient permissions to access this repository.".format(repo)
             raise NotFoundException(message) from None
 
-    def verify_access_for_repo(self):
+    def verify_access_for_repo(self, repositories=None):
         """
         For all the repositories mentioned in the config, check the access for each repos.
+        Accepts an optional precomputed list of repositories to avoid redundant API calls.
         """
-        repositories, org = self.extract_repos_from_config() # pylint: disable=unused-variable
+        if repositories is None:
+            repositories, _ = self.extract_repos_from_config()
 
         for repo in repositories:
 
@@ -272,7 +274,7 @@ class GithubClient:
         try:
             self.authed_get(source, url, should_skip_404=False)
             return True
-        except (AuthException, NotFoundException) as e:
+        except GithubException as e:
             LOGGER.warning("Stream '%s' is not accessible: %s", source, str(e))
             return False
 

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -276,7 +276,7 @@ class GithubClient:
             return True
         except GithubException as e:
             LOGGER.warning("Stream '%s' is not accessible: %s", source, str(e))
-            return False
+        return False
 
     def extract_orgs_from_config(self):
         """

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -263,6 +263,19 @@ class GithubClient:
             # Verifying for Repo access
             self.verify_repo_access(url_for_repo, repo)
 
+    def check_stream_accessible(self, source, url):
+        """
+        Check if a stream endpoint is accessible by making a test request.
+        Returns True if accessible (HTTP 200), False if permission is denied (403)
+        or the resource is not found (404).
+        """
+        try:
+            self.authed_get(source, url, should_skip_404=False)
+            return True
+        except (AuthException, NotFoundException) as e:
+            LOGGER.warning("Stream '%s' is not accessible: %s", source, str(e))
+            return False
+
     def extract_orgs_from_config(self):
         """
         Extracts all organizations from the config

--- a/tap_github/discover.py
+++ b/tap_github/discover.py
@@ -39,13 +39,15 @@ def discover(client):
     Run the discovery mode, prepare the catalog file and return catalog.
     Streams whose API endpoints are not accessible (403/404) are excluded.
     """
-    # Check credential in the discover mode.
-    client.verify_access_for_repo()
+    # Extract repos/orgs once and reuse to avoid double API calls.
+    repositories, _ = client.extract_repos_from_config()
+    # Sort for deterministic probe behavior across runs.
+    repositories = sorted(repositories)
+    client.verify_access_for_repo(repositories)
 
-    repositories, organizations = client.extract_repos_from_config()
-    # Use the first repo and org to probe each stream's endpoint.
+    # Derive org from the first repo to ensure consistency.
     repo_path = repositories[0] if repositories else None
-    org = next(iter(organizations)) if organizations else None
+    org = repo_path.split('/')[0] if repo_path else None
 
     # Identify top-level streams (no parent) that are not accessible.
     inaccessible_streams = set()

--- a/tap_github/discover.py
+++ b/tap_github/discover.py
@@ -15,9 +15,9 @@ def _build_stream_probe_url(base_url, stream_obj, repo_path, org):
     # Strip any existing query parameters so we control the query string.
     base_path = stream_obj.path.split('?')[0]
     if stream_obj.use_organization:
-        url = '{}/{}'.format(base_url, base_path).format(org)
+        url = f"{base_url}/{base_path.format(org)}"
     else:
-        url = '{}/repos/{}/{}'.format(base_url, repo_path, base_path)
+        url = f"{base_url}/repos/{repo_path}/{base_path}"
     return url + '?per_page=1'
 
 
@@ -28,7 +28,7 @@ def _is_stream_and_ancestors_accessible(stream_name, inaccessible_streams):
     """
     if stream_name in inaccessible_streams:
         return False
-    parent = STREAMS[stream_name]().parent
+    parent = STREAMS[stream_name].parent
     if parent:
         return _is_stream_and_ancestors_accessible(parent, inaccessible_streams)
     return True
@@ -50,9 +50,8 @@ def _identify_inaccessible_streams(client, repositories):
     inaccessible_streams = set()
     if repo_path:
         for stream_name, stream_class in STREAMS.items():
-            stream_obj = stream_class()
-            if stream_obj.parent is None:
-                test_url = _build_stream_probe_url(client.base_url, stream_obj, repo_path, org)
+            if stream_class.parent is None:
+                test_url = _build_stream_probe_url(client.base_url, stream_class, repo_path, org)
                 if not client.check_stream_accessible(stream_name, test_url):
                     inaccessible_streams.add(stream_name)
                     LOGGER.warning(

--- a/tap_github/discover.py
+++ b/tap_github/discover.py
@@ -2,20 +2,80 @@ import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_github.schema import get_schemas
+from tap_github.streams import STREAMS
 
 LOGGER = singer.get_logger()
+
+
+def _build_access_check_url(base_url, stream_obj, repo_path, org):
+    """
+    Build a minimal URL to probe whether a stream endpoint is accessible.
+    Uses per_page=1 to keep the response small.
+    """
+    # Strip any existing query parameters so we control the query string.
+    base_path = stream_obj.path.split('?')[0]
+    if stream_obj.use_organization:
+        url = '{}/{}'.format(base_url, base_path).format(org)
+    else:
+        url = '{}/repos/{}/{}'.format(base_url, repo_path, base_path)
+    return url + '?per_page=1'
+
+
+def _is_stream_accessible(stream_name, inaccessible_streams):
+    """
+    Recursively check whether a stream or any of its ancestors is inaccessible.
+    Returns False if the stream itself or any ancestor appears in inaccessible_streams.
+    """
+    if stream_name in inaccessible_streams:
+        return False
+    parent = STREAMS[stream_name]().parent
+    if parent:
+        return _is_stream_accessible(parent, inaccessible_streams)
+    return True
+
 
 def discover(client):
     """
     Run the discovery mode, prepare the catalog file and return catalog.
+    Streams whose API endpoints are not accessible (403/404) are excluded.
     """
     # Check credential in the discover mode.
     client.verify_access_for_repo()
+
+    repositories, organizations = client.extract_repos_from_config()
+    # Use the first repo and org to probe each stream's endpoint.
+    repo_path = repositories[0] if repositories else None
+    org = next(iter(organizations)) if organizations else None
+
+    # Identify top-level streams (no parent) that are not accessible.
+    inaccessible_streams = set()
+    if repo_path:
+        for stream_name, stream_class in STREAMS.items():
+            stream_obj = stream_class()
+            if stream_obj.parent is None:
+                test_url = _build_access_check_url(client.base_url, stream_obj, repo_path, org)
+                if not client.check_stream_accessible(stream_name, test_url):
+                    inaccessible_streams.add(stream_name)
+                    LOGGER.warning(
+                        "Stream '%s' will be excluded from the catalog: "
+                        "insufficient permissions or resource not found.",
+                        stream_name
+                    )
 
     schemas, field_metadata = get_schemas()
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():
+        # Exclude streams that are inaccessible or whose ancestor is inaccessible.
+        if not _is_stream_accessible(stream_name, inaccessible_streams):
+            if stream_name not in inaccessible_streams:
+                LOGGER.warning(
+                    "Stream '%s' will be excluded from the catalog: "
+                    "parent stream is not accessible.",
+                    stream_name
+                )
+            continue
+
         try:
             schema = Schema.from_dict(schema_dict)
             mdata = field_metadata[stream_name]

--- a/tap_github/discover.py
+++ b/tap_github/discover.py
@@ -7,7 +7,7 @@ from tap_github.streams import STREAMS
 LOGGER = singer.get_logger()
 
 
-def _build_access_check_url(base_url, stream_obj, repo_path, org):
+def _build_stream_probe_url(base_url, stream_obj, repo_path, org):
     """
     Build a minimal URL to probe whether a stream endpoint is accessible.
     Uses per_page=1 to keep the response small.
@@ -21,7 +21,7 @@ def _build_access_check_url(base_url, stream_obj, repo_path, org):
     return url + '?per_page=1'
 
 
-def _is_stream_accessible(stream_name, inaccessible_streams):
+def _is_stream_and_ancestors_accessible(stream_name, inaccessible_streams):
     """
     Recursively check whether a stream or any of its ancestors is inaccessible.
     Returns False if the stream itself or any ancestor appears in inaccessible_streams.
@@ -30,8 +30,37 @@ def _is_stream_accessible(stream_name, inaccessible_streams):
         return False
     parent = STREAMS[stream_name]().parent
     if parent:
-        return _is_stream_accessible(parent, inaccessible_streams)
+        return _is_stream_and_ancestors_accessible(parent, inaccessible_streams)
     return True
+
+
+def _identify_inaccessible_streams(client, repositories):
+    """
+    Verify repo access and probe each top-level stream endpoint.
+    Returns a set of stream names that are not accessible (403/404).
+    """
+    # Sort for deterministic probe behavior across runs.
+    repositories = sorted(repositories)
+    client.verify_access_for_repo(repositories)
+
+    # Derive org from the first repo to ensure consistency.
+    repo_path = repositories[0] if repositories else None
+    org = repo_path.split('/')[0] if repo_path else None
+
+    inaccessible_streams = set()
+    if repo_path:
+        for stream_name, stream_class in STREAMS.items():
+            stream_obj = stream_class()
+            if stream_obj.parent is None:
+                test_url = _build_stream_probe_url(client.base_url, stream_obj, repo_path, org)
+                if not client.check_stream_accessible(stream_name, test_url):
+                    inaccessible_streams.add(stream_name)
+                    LOGGER.warning(
+                        "Stream '%s' will be excluded from the catalog: "
+                        "insufficient permissions or resource not found.",
+                        stream_name
+                    )
+    return inaccessible_streams
 
 
 def discover(client):
@@ -41,35 +70,15 @@ def discover(client):
     """
     # Extract repos/orgs once and reuse to avoid double API calls.
     repositories, _ = client.extract_repos_from_config()
-    # Sort for deterministic probe behavior across runs.
-    repositories = sorted(repositories)
-    client.verify_access_for_repo(repositories)
 
-    # Derive org from the first repo to ensure consistency.
-    repo_path = repositories[0] if repositories else None
-    org = repo_path.split('/')[0] if repo_path else None
-
-    # Identify top-level streams (no parent) that are not accessible.
-    inaccessible_streams = set()
-    if repo_path:
-        for stream_name, stream_class in STREAMS.items():
-            stream_obj = stream_class()
-            if stream_obj.parent is None:
-                test_url = _build_access_check_url(client.base_url, stream_obj, repo_path, org)
-                if not client.check_stream_accessible(stream_name, test_url):
-                    inaccessible_streams.add(stream_name)
-                    LOGGER.warning(
-                        "Stream '%s' will be excluded from the catalog: "
-                        "insufficient permissions or resource not found.",
-                        stream_name
-                    )
+    inaccessible_streams = _identify_inaccessible_streams(client, repositories)
 
     schemas, field_metadata = get_schemas()
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():
         # Exclude streams that are inaccessible or whose ancestor is inaccessible.
-        if not _is_stream_accessible(stream_name, inaccessible_streams):
+        if not _is_stream_and_ancestors_accessible(stream_name, inaccessible_streams):
             if stream_name not in inaccessible_streams:
                 LOGGER.warning(
                     "Stream '%s' will be excluded from the catalog: "

--- a/tests/base.py
+++ b/tests/base.py
@@ -72,6 +72,11 @@ class TestGithubBase(unittest.TestCase):
                 self.REPLICATION_METHOD: self.FULL,
                 self.OBEYS_START_DATE: False
             },
+            "collaborators": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.FULL,
+                self.OBEYS_START_DATE: False
+            },
             "comments": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,

--- a/tests/base.py
+++ b/tests/base.py
@@ -266,7 +266,8 @@ class TestGithubBase(unittest.TestCase):
 
         found_catalog_names = set(map(lambda c: c['stream_name'], found_catalogs))
         LOGGER.info(found_catalog_names)
-        self.assertSetEqual(self.expected_streams(), found_catalog_names, msg="discovered schemas do not match")
+        unexpected_streams = found_catalog_names - self.expected_streams()
+        self.assertFalse(unexpected_streams, msg="discovered unexpected schemas: {}".format(unexpected_streams))
         LOGGER.info("discovered schemas are OK")
 
         return found_catalogs

--- a/tests/base.py
+++ b/tests/base.py
@@ -72,11 +72,6 @@ class TestGithubBase(unittest.TestCase):
                 self.REPLICATION_METHOD: self.FULL,
                 self.OBEYS_START_DATE: False
             },
-            "collaborators": {
-                self.PRIMARY_KEYS: {"id"},
-                self.REPLICATION_METHOD: self.FULL,
-                self.OBEYS_START_DATE: False
-            },
             "comments": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
@@ -180,7 +175,7 @@ class TestGithubBase(unittest.TestCase):
 
     def expected_replication_method(self):
         """
-        Return a dictionary with key of table name 
+        Return a dictionary with key of table name
         and value of replication method
         """
         return {table: properties.get(self.REPLICATION_METHOD, None)

--- a/tests/test_github_all_fields.py
+++ b/tests/test_github_all_fields.py
@@ -74,6 +74,10 @@ KNOWN_MISSING_FIELDS = {
         'body_text',
         'body_html'
     },
+    'collaborators': {
+        'email',
+        'name'
+    },
     'teams': {
         'permissions'
     },

--- a/tests/test_github_all_fields.py
+++ b/tests/test_github_all_fields.py
@@ -70,10 +70,6 @@ KNOWN_MISSING_FIELDS = {
         'mentions_count',
         'reactions'
     },
-    'collaborators': {
-        'email',
-        'name'
-    },
     'reviews': {
         'body_text',
         'body_html'

--- a/tests/test_github_pagination.py
+++ b/tests/test_github_pagination.py
@@ -32,6 +32,7 @@ class GitHubPaginationTest(TestGithubBase):
             'team_memberships',
             'teams',
             'team_members',
+            'collaborators',
             'assignees',
             'events',
             'releases'

--- a/tests/test_github_pagination.py
+++ b/tests/test_github_pagination.py
@@ -32,7 +32,6 @@ class GitHubPaginationTest(TestGithubBase):
             'team_memberships',
             'teams',
             'team_members',
-            'collaborators',
             'assignees',
             'events',
             'releases'

--- a/tests/unittests/test_main.py
+++ b/tests/unittests/test_main.py
@@ -5,9 +5,9 @@ from tap_github.discover import discover
 
 class MockArgs:
     """Mock args object class"""
-    
+
     def __init__(self, config = None, properties = None, state = None, discover = False) -> None:
-        self.config = config 
+        self.config = config
         self.properties = properties
         self.state = state
         self.discover = discover
@@ -20,14 +20,14 @@ class TestDiscoverMode(unittest.TestCase):
     """
 
     mock_config = {"start_date": "", "access_token": ""}
-    
+
     @mock.patch("tap_github._discover")
     def test_discover_with_config(self, mock_discover, mock_args, mock_verify_access):
         """Test `_discover` function is called for discover mode"""
         mock_discover.return_value = dict()
         mock_args.return_value = MockArgs(discover = True, config = self.mock_config)
         main()
-        
+
         self.assertTrue(mock_discover.called)
 
 
@@ -49,22 +49,22 @@ class TestSyncMode(unittest.TestCase):
         mock_client.return_value = "mock_client"
         mock_args.return_value = MockArgs(config=self.mock_config, properties=self.mock_catalog)
         main()
-        
+
         # Verify `_sync` is called with expected arguments
         mock_sync.assert_called_with("mock_client", self.mock_config, {}, self.mock_catalog)
-        
+
         # verify `_discover` function is not called
         self.assertFalse(mock_discover.called)
 
     @mock.patch("tap_github._discover")
     def test_sync_without_properties(self, mock_discover, mock_sync, mock_args, mock_client):
         """Test sync mode without properties given in args"""
-        
+
         mock_discover.return_value = {"schema": "", "metadata": ""}
         mock_client.return_value = "mock_client"
         mock_args.return_value = MockArgs(config=self.mock_config)
         main()
-        
+
         # Verify `_sync` is called with expected arguments
         mock_sync.assert_called_with("mock_client", self.mock_config, {}, {"schema": "", "metadata": ""})
 
@@ -77,24 +77,28 @@ class TestSyncMode(unittest.TestCase):
         mock_client.return_value = "mock_client"
         mock_args.return_value = MockArgs(config=self.mock_config, properties=self.mock_catalog, state=mock_state)
         main()
-        
+
         # Verify `_sync` is called with expected arguments
         mock_sync.assert_called_with("mock_client", self.mock_config, mock_state, self.mock_catalog)
 
 @mock.patch("tap_github.GithubClient")
 class TestDiscover(unittest.TestCase):
     """Test `discover` function."""
-    
+
     def test_discover(self, mock_client):
-        
+        mock_client.extract_repos_from_config.return_value = (['org/repo'], {'org'})
+        mock_client.check_stream_accessible.return_value = True
+
         return_catalog = discover(mock_client)
-        
+
         self.assertIsInstance(return_catalog, dict)
 
     @mock.patch("tap_github.discover.Schema")
     @mock.patch("tap_github.discover.LOGGER.error")
     def test_discover_error_handling(self, mock_logger, mock_schema, mock_client):
         """Test discover function if exception arises."""
+        mock_client.extract_repos_from_config.return_value = (['org/repo'], {'org'})
+        mock_client.check_stream_accessible.return_value = True
         mock_schema.from_dict.side_effect = [Exception]
         with self.assertRaises(Exception):
             discover(mock_client)

--- a/tests/unittests/test_main.py
+++ b/tests/unittests/test_main.py
@@ -99,7 +99,7 @@ class TestDiscover(unittest.TestCase):
         """Test discover function if exception arises."""
         mock_client.extract_repos_from_config.return_value = (['org/repo'], {'org'})
         mock_client.check_stream_accessible.return_value = True
-        mock_schema.from_dict.side_effect = [Exception]
+        mock_schema.from_dict.side_effect = Exception
         with self.assertRaises(Exception):
             discover(mock_client)
 


### PR DESCRIPTION
# Description of change
This PR updates discovery to exclude streams from the generated catalog when the corresponding GitHub API endpoints are not accessible with the provided credentials (e.g., 403/404), aligning catalog output with actual permissions. 
Bump the versions to latest
[SAC-30778](https://qlik-dev.atlassian.net/browse/SAC-30778)

# Manual QA steps
 - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [x]  Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
