### PR TITLE
fix malformed URL causing 'since' filter to be dropped for Issues and Comments streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 3.3.4
+  * Fix malformed URL causing 'since' filter to be dropped for Issues and Comments streams [#230](https://github.com/singer-io/tap-github/pull/230)
+
 # 3.3.3
   * Fix `translate_state` to not delete state [#224](https://github.com/singer-io/tap-github/pull/224)
     * Add unit tests to prove there's a bug and prevent future regression

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='3.3.3',
+      version='3.3.4',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-github',
       py_modules=['tap_github'],
       install_requires=[
           'singer-python==5.12.1',
-          'requests==2.32.4',
+          'requests==2.33.0',
           'backoff==1.8.0'
       ],
       extras_require={

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -75,7 +75,7 @@ class Stream:
         """
         if self.filter_param:
             # Use '&' if the path already contains a query string, otherwise '?'
-            separator = '&' if '?' in self.path else '?'
+            separator = '&' if '?' in (self.path or '') else '?'
             query_string = '{}since={}'.format(separator, bookmark)
         else:
             query_string = ''
@@ -388,6 +388,7 @@ class IncrementalOrderedStream(Stream):
             ):
                 records = response.json()
                 extraction_time = singer.utils.now()
+
                 for record in records:
                     record['_sdc_repository'] = repo_path
                     self.add_fields_at_1st_level(record = record, parent_record = None)

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -74,8 +74,9 @@ class Stream:
         Build the full url with parameters and attributes.
         """
         if self.filter_param:
-            # Add the since parameter for incremental streams
-            query_string = '?since={}'.format(bookmark)
+            # Use '&' if the path already contains a query string, otherwise '?'
+            separator = '&' if '?' in self.path else '?'
+            query_string = '{}since={}'.format(separator, bookmark)
         else:
             query_string = ''
 

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -62,7 +62,7 @@ class TestBuildUrl(unittest.TestCase):
     """
 
     @parameterized.expand([
-        ["test_stream_with_filter_params", "org/test-repo", "https://api.github.com/repos/org/test-repo/issues/comments?sort=updated&direction=desc?since=2022-01-01T00:00:00Z", Comments],
+        ["test_stream_with_filter_params", "org/test-repo", "https://api.github.com/repos/org/test-repo/issues/comments?sort=updated&direction=desc&since=2022-01-01T00:00:00Z", Comments],
         ["test_stream_with_organization", "org", "https://api.github.com/orgs/org/teams", Teams]
     ])
     def test_build_url(self, name, param, expected_url, stream_class):

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from tap_github.streams import Comments, Reviews, TeamMemberships, Teams, PullRequests, get_schema, get_child_full_url, get_bookmark
+from tap_github.streams import Comments, Reviews, TeamMemberships, Teams, PullRequests, Commits, Issues, get_schema, get_child_full_url, get_bookmark
 from parameterized import parameterized
 
 
@@ -62,8 +62,21 @@ class TestBuildUrl(unittest.TestCase):
     """
 
     @parameterized.expand([
-        ["test_stream_with_filter_params", "org/test-repo", "https://api.github.com/repos/org/test-repo/issues/comments?sort=updated&direction=desc&since=2022-01-01T00:00:00Z", Comments],
-        ["test_stream_with_organization", "org", "https://api.github.com/orgs/org/teams", Teams]
+        # Path already has '?' — since must be appended with '&'
+        ["comments_appends_ampersand_since", "org/test-repo",
+         "https://api.github.com/repos/org/test-repo/issues/comments?sort=updated&direction=desc&since=2022-01-01T00:00:00Z",
+         Comments],
+        ["issues_appends_ampersand_since", "org/test-repo",
+         "https://api.github.com/repos/org/test-repo/issues?state=all&sort=updated&direction=desc&since=2022-01-01T00:00:00Z",
+         Issues],
+        # Path has no '?' — since must be appended with '?'
+        ["commits_appends_question_mark_since", "org/test-repo",
+         "https://api.github.com/repos/org/test-repo/commits?since=2022-01-01T00:00:00Z",
+         Commits],
+        # Org-level stream with no filter_param — no since appended
+        ["teams_org_url_no_since", "org",
+         "https://api.github.com/orgs/org/teams",
+         Teams],
     ])
     def test_build_url(self, name, param, expected_url, stream_class):
         """


### PR DESCRIPTION
# Description of change
`build_url` always appended `?since=` to the URL, but the Issues and Comments stream paths already contain a query string (e.g. `issues?state=all&sort=updated&direction=desc`). This produced a malformed URL with a double ?: 
`/issues?state=all&sort=updated&direction=desc?since=2026-04-30T16:55:02Z`

GitHub parses everything after the first ? as the query string, so direction received the value `desc?since=...` (invalid) and `since` was never recognized as a parameter. With direction malformed, GitHub could return records in ascending order — causing `IncrementalOrderedStream` to hit `synced_all_records = True` on the first old record and drop all recently updated issues.

# Manual QA steps
 - Ran the tap, updated an Issue and saw that it was not replicated
 - Ran new code, verified the updated Issue was replicated.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
