### PR TITLE
Added fix for GitHub's transient fault issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 # 3.4.1
-  * Retry transient 401 responses in `authed_get` by including `BadCredentialsException` in backoff retries.
+  * Retry transient 401 responses in `authed_get` by including `BadCredentialsException` in backoff retries. [#234](https://github.com/singer-io/tap-github/pull/234)
   * Rationale: GitHub has documented intermittent API-side auth/routing incidents where valid requests can return temporary 401 and succeed on retry.
 
 # 3.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 3.4.1
+  * Retry transient 401 responses in `authed_get` by including `BadCredentialsException` in backoff retries.
+  * Rationale: GitHub has documented intermittent API-side auth/routing incidents where valid requests can return temporary 401 and succeed on retry.
+
 # 3.4.0
   * Exclude 403-forbidden streams from discovery [#229](https://github.com/singer-io/tap-github/pull/229)
   * Bump dependencies for compliance

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='3.4.0',
+      version='3.4.1',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -196,7 +196,11 @@ class GithubClient:
     # pylint: disable=dangerous-default-value
     # During 'Timeout' error there is also possibility of 'ConnectionError',
     # hence added backoff for 'ConnectionError' too.
-    @backoff.on_exception(backoff.expo, (requests.Timeout, requests.ConnectionError, Server5xxError, TooManyRequests), max_tries=5, factor=2)
+    # GitHub has documented intermittent transient 401 responses where retrying
+    # eventually succeeds during API-side routing incidents. Retrying
+    # BadCredentialsException helps discovery/sync survive these short-lived
+    # faults while still failing after max_tries for persistent invalid tokens.
+    @backoff.on_exception(backoff.expo, (requests.Timeout, requests.ConnectionError, Server5xxError, TooManyRequests, BadCredentialsException), max_tries=5, factor=2)
     def authed_get(self, source, url, headers={}, stream="", should_skip_404 = True):
         """
         Call rest API and return the response in case of status code 200.

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -76,8 +76,8 @@ class TestExceptionHandling(unittest.TestCase):
     def test_error_message_and_call_count(self, mocked_parse_args, mocked_request, mock_verify_access, mock_sleep, erro_code, error_msg, error_class, content, json_msg, call_count):
         """
         - Verify that `authed_get` raises an error with the proper message for different error codes.
-                - Verify that tap retries 5 times for Server5xxError, TooManyRequests,
-                    and transient 401 BadCredentialsException.
+        - Verify that tap retries 5 times for Server5xxError, TooManyRequests, 
+        and transient 401 BadCredentialsException.
         """
         mocked_request.return_value = get_response(erro_code, json = json_msg, raise_error = True, content = content)
         test_client = GithubClient(self.config)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -63,7 +63,7 @@ class TestExceptionHandling(unittest.TestCase):
 
     @parameterized.expand([
         [400, "The request is missing or has a bad parameter.", BadRequestException, '', {}, 1],
-        [401, "Invalid authorization credentials.", BadCredentialsException, '', {}, 1],
+        [401, "Invalid authorization credentials.", BadCredentialsException, '', {}, 5],
         [403, "User doesn't have permission to access the resource.", AuthException, '', {}, 1],
         [500, "An error has occurred at Github's end.", InternalServerError, '', {}, 5],
         [301, "The resource you are looking for is moved to another URL.", tap_github.client.MovedPermanentlyError, '', {}, 1],
@@ -76,7 +76,8 @@ class TestExceptionHandling(unittest.TestCase):
     def test_error_message_and_call_count(self, mocked_parse_args, mocked_request, mock_verify_access, mock_sleep, erro_code, error_msg, error_class, content, json_msg, call_count):
         """
         - Verify that `authed_get` raises an error with the proper message for different error codes.
-        - Verify that tap retries 5 times for Server5xxError and RateLimitExceeded error.
+                - Verify that tap retries 5 times for Server5xxError, TooManyRequests,
+                    and transient 401 BadCredentialsException.
         """
         mocked_request.return_value = get_response(erro_code, json = json_msg, raise_error = True, content = content)
         test_client = GithubClient(self.config)


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31798
Added BadCredentialsException to the backoff retry tuple in client.py:203.
Added inline rationale in client.py:199 documenting why 401 retries are needed for transient GitHub faults.
Updated unit test expectation for 401 retry behavior in

# Manual QA steps
- [x] Discovery: Running
- [x] Sync: Running
- [x] Unit Tests: Running
- [x] Integration Tests: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
